### PR TITLE
Replace slf4j with log4j to unify our logging

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -33,7 +33,6 @@ dependencyResolutionManagement {
       version("protobuf", "3.20.1")
       version("grpc", "1.45.1")
 
-      version("slf4j", "1.7.36")
       version("log4j", "2.17.2")
       version("javax-annotation", "1.3.2")
 
@@ -59,10 +58,8 @@ dependencyResolutionManagement {
       library("grpc-protobuf", "io.grpc", "grpc-protobuf").versionRef("grpc")
       library("grpc-netty-shaded", "io.grpc", "grpc-netty-shaded").versionRef("grpc")
 
-      library("slf4j", "org.slf4j", "slf4j-api").versionRef("slf4j")
       library("log4j-api", "org.apache.logging.log4j", "log4j-api").versionRef("log4j")
       library("log4j-core", "org.apache.logging.log4j", "log4j-core").versionRef("log4j")
-      library("log4j-slf4j", "org.apache.logging.log4j", "log4j-slf4j18-impl").versionRef("log4j")
       library("javax-annotation-api", "javax.annotation", "javax.annotation-api")
           .versionRef("javax-annotation")
 

--- a/test-utils/build.gradle.kts
+++ b/test-utils/build.gradle.kts
@@ -17,7 +17,7 @@ dependencies {
   implementation(libs.jackson.databind)
   implementation(libs.jackson.yaml)
 
-  implementation(libs.slf4j)
+  implementation(libs.log4j.api)
   implementation(libs.grpc.netty.shaded)
 
   testImplementation(libs.junit.all)

--- a/test-utils/src/main/kotlin/dev/restate/e2e/utils/RestateDeployer.kt
+++ b/test-utils/src/main/kotlin/dev/restate/e2e/utils/RestateDeployer.kt
@@ -8,7 +8,7 @@ import java.nio.file.Files
 import java.nio.file.Path
 import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
-import org.slf4j.LoggerFactory
+import org.apache.logging.log4j.LogManager
 import org.testcontainers.containers.GenericContainer
 import org.testcontainers.containers.Network
 import org.testcontainers.images.PullPolicy
@@ -30,7 +30,7 @@ private constructor(
     private const val IMAGE_PULL_POLICY = "E2E_IMAGE_PULL_POLICY"
     private const val ALWAYS_PULL = "always"
 
-    private val logger = LoggerFactory.getLogger(RestateDeployer::class.java)
+    private val logger = LogManager.getLogger(RestateDeployer::class.java)
 
     @JvmStatic
     fun builder(): Builder {

--- a/tests/build.gradle.kts
+++ b/tests/build.gradle.kts
@@ -13,9 +13,8 @@ dependencies {
   testImplementation(libs.junit.all)
   testImplementation(libs.assertj)
 
-  testRuntimeOnly(libs.log4j.api)
+  testImplementation(libs.log4j.api)
   testRuntimeOnly(libs.log4j.core)
-  testRuntimeOnly(libs.log4j.slf4j)
 
   testImplementation(platform(libs.jackson.bom))
   testImplementation(libs.jackson.core)

--- a/tests/src/test/kotlin/dev/restate/e2e/KafkaInvocationTest.kt
+++ b/tests/src/test/kotlin/dev/restate/e2e/KafkaInvocationTest.kt
@@ -3,24 +3,20 @@ package dev.restate.e2e
 import com.google.protobuf.Empty
 import dev.restate.e2e.functions.counter.CounterGrpc
 import dev.restate.e2e.functions.counter.CounterGrpc.CounterBlockingStub
-import dev.restate.e2e.utils.InjectBlockingStub
-import dev.restate.e2e.utils.InjectContainerAddress
-import dev.restate.e2e.utils.KafkaContainer
-import dev.restate.e2e.utils.RestateDeployer
-import dev.restate.e2e.utils.RestateDeployerExtension
+import dev.restate.e2e.utils.*
 import io.cloudevents.CloudEvent
 import io.cloudevents.core.message.Encoding
 import io.cloudevents.kafka.CloudEventSerializer
-import java.util.*
 import org.apache.kafka.clients.producer.KafkaProducer
 import org.apache.kafka.clients.producer.ProducerConfig
 import org.apache.kafka.common.serialization.StringSerializer
+import org.apache.logging.log4j.LogManager
 import org.awaitility.kotlin.await
 import org.awaitility.kotlin.matches
 import org.awaitility.kotlin.untilCallTo
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.RegisterExtension
-import org.slf4j.LoggerFactory
+import java.util.*
 
 class KafkaInvocationTest {
 
@@ -29,7 +25,7 @@ class KafkaInvocationTest {
     const val KEY_A = "a"
     const val KEY_B = "b"
 
-    private val logger = LoggerFactory.getLogger(KafkaInvocationTest::class.java)
+    private val logger = LogManager.getLogger(KafkaInvocationTest::class.java)
 
     @RegisterExtension
     val deployerExt: RestateDeployerExtension =


### PR DESCRIPTION
Replace slf4j with log4j to unify our logging