### PR TITLE
Set timeouts for Github workflows

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -13,6 +13,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/publish-snapshot.yml
+++ b/.github/workflows/publish-snapshot.yml
@@ -11,6 +11,7 @@ jobs:
     if: github.repository == 'restatedev/e2e'
     name: Publish snapshot (Java ${{ matrix.java }})
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
This commit sets a timeout of 15 minutes for the Github workflows.

This fixes #42.