### PR TITLE
Fix cron schedule to 0th minute in order to avoid multiple runs

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -7,7 +7,7 @@ on:
   pull_request:
     branches: [ main ]
   schedule:
-    - cron: '* */6 * * *' # Every 6 hours
+    - cron: '0 */6 * * *' # Every 6 hours
   workflow_dispatch: # To start from UI
 
 jobs:


### PR DESCRIPTION
`* *\6 * * *` says at every minute every 6th hour. That explains as well why we are seeing multiple scheduled runs every 6 hours.

This fixes #45.