### PR TITLE
Add support for deploying e2e testing artifacts to JFrog

### DIFF
--- a/.github/workflows/publish-snapshot.yml
+++ b/.github/workflows/publish-snapshot.yml
@@ -2,6 +2,15 @@ name: Publish snapshot
 
 on:
   workflow_dispatch:
+    inputs:
+      deploymentTarget:
+        description: 'Deployment target'
+        required: true
+        default: 'GitHub'
+        type: choice
+        options:
+          - GitHub
+          - JFrog
   push:
     branches:
       - main
@@ -34,9 +43,18 @@ jobs:
           package-name: 'dev.restate.testing.e2e-utils'
           delete-only-pre-release-versions: "true"
           token: ${{ secrets.GITHUB_TOKEN }}
-      - name: Build with Gradle
+      - name: Build with Gradle & publish to JFrog repository
+        if: ${{ inputs.deploymentTarget == 'JFrog' }}
+        uses: gradle/gradle-build-action@v2
+        env:
+          JFROG_USERNAME: ${{ secrets.JFROG_USERNAME }}
+          JFROG_TOKEN: ${{secrets.JFROG_TOKEN }}
+        with:
+          arguments: publishMavenPublicationToJFrogRepository
+      - name: Build with Gradle & publish to GitHub packages repository
+        if: ${{ inputs.deploymentTarget != 'JFrog' }}
         uses: gradle/gradle-build-action@v2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          arguments: publish
+          arguments: publishMavenPublicationToGitHubPackagesRepository

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -19,6 +19,8 @@ allprojects {
   apply(plugin = "kotlin")
   apply(plugin = "com.diffplug.spotless")
 
+  version = "1.0-SNAPSHOT"
+
   configure<com.diffplug.gradle.spotless.SpotlessExtension> {
     kotlin { ktfmt() }
     kotlinGradle { ktfmt() }

--- a/test-utils/build.gradle.kts
+++ b/test-utils/build.gradle.kts
@@ -24,6 +24,11 @@ dependencies {
   testImplementation(libs.assertj)
 }
 
+java {
+  withJavadocJar()
+  withSourcesJar()
+}
+
 publishing {
   repositories {
     maven {
@@ -34,12 +39,24 @@ publishing {
         password = System.getenv("GITHUB_TOKEN")
       }
     }
+
+    maven {
+      name = "JFrog"
+      val releasesRepoUrl = uri("https://restatedev.jfrog.io/artifactory/restatedev-libs-release")
+      val snapshotsRepoUrl = uri("https://restatedev.jfrog.io/artifactory/restatedev-libs-snapshot")
+      url = uri(if (version.toString().endsWith("SNAPSHOT")) snapshotsRepoUrl else releasesRepoUrl)
+
+      credentials {
+        username = System.getenv("JFROG_USERNAME")
+        password = System.getenv("JFROG_TOKEN")
+      }
+    }
   }
+
   publications {
-    register<MavenPublication>("gpr") {
+    register<MavenPublication>("maven") {
       groupId = "dev.restate.testing"
       artifactId = "e2e-utils"
-      version = "1.0-SNAPSHOT"
 
       from(components["java"])
     }


### PR DESCRIPTION
This commit extends the test-utils/build.gradle.kts to deploy to JFrog. The
credentials are passed in via JFROG_USERNAME and JFROG_TOKEN. Moreover, it
adjusts the publish-snapshot.yml workflow to also deploy to JFrog if manually
triggered.

This fixes https://github.com/restatedev/e2e/issues/47.

This PR is based on #46.