### PR TITLE
Remove usages of channel, async and asyncDefer

### DIFF
--- a/functions/counter/impl/src/main/java/dev/restate/e2e/functions/counter/NoopService.java
+++ b/functions/counter/impl/src/main/java/dev/restate/e2e/functions/counter/NoopService.java
@@ -17,7 +17,10 @@ public class NoopService extends NoopGrpc.NoopImplBase {
     RestateContext ctx = RestateContext.current();
 
     // Increment the counter
-    ctx.fireAndForget(CounterGrpc.getAddMethod(), "doAndReportInvocationCount", Number.newBuilder().setValue(1).build());
+    ctx.backgroundCall(
+        CounterGrpc.getAddMethod(),
+        "doAndReportInvocationCount",
+        Number.newBuilder().setValue(1).build());
 
     responseObserver.onNext(Empty.getDefaultInstance());
     responseObserver.onCompleted();

--- a/functions/errors/impl/src/main/java/dev/restate/e2e/functions/errors/FailingService.java
+++ b/functions/errors/impl/src/main/java/dev/restate/e2e/functions/errors/FailingService.java
@@ -3,7 +3,6 @@ package dev.restate.e2e.functions.errors;
 import com.google.protobuf.Empty;
 import dev.restate.e2e.functions.utils.NumberSortHttpServerUtils;
 import dev.restate.sdk.RestateContext;
-import dev.restate.sdk.SuspendableException;
 import io.grpc.Status;
 import io.grpc.StatusRuntimeException;
 import io.grpc.stub.StreamObserver;
@@ -29,10 +28,11 @@ public class FailingService extends FailingServiceGrpc.FailingServiceImplBase {
     LOG.info("Invoked failAndHandle");
 
     try {
-      ctx.invoke(
+      ctx.call(
               FailingServiceGrpc.getFailMethod(),
-              ctx.withSideEffect(String.class, () -> UUID.randomUUID().toString()),
-              request).await();
+              ctx.sideEffect(String.class, () -> UUID.randomUUID().toString()),
+              request)
+          .await();
     } catch (StatusRuntimeException e) {
       responseObserver.onNext(
           ErrorMessage.newBuilder().setErrorMessage(e.getStatus().getDescription()).build());
@@ -53,7 +53,7 @@ public class FailingService extends FailingServiceGrpc.FailingServiceImplBase {
     String finalMessage = "begin";
 
     try {
-      ctx.asyncCall(
+      ctx.callback(
               byte[].class,
               replyId -> {
                 try {
@@ -70,10 +70,11 @@ public class FailingService extends FailingServiceGrpc.FailingServiceImplBase {
     }
 
     try {
-      ctx.invoke(
+      ctx.call(
               FailingServiceGrpc.getFailMethod(),
-              ctx.withSideEffect(String.class, () -> UUID.randomUUID().toString()),
-              ErrorMessage.newBuilder().setErrorMessage("internal_call").build()).await();
+              ctx.sideEffect(String.class, () -> UUID.randomUUID().toString()),
+              ErrorMessage.newBuilder().setErrorMessage("internal_call").build())
+          .await();
     } catch (StatusRuntimeException e) {
       finalMessage = finalMessage + ":" + e.getStatus().getDescription();
     }

--- a/functions/externalcall/impl/src/main/java/dev/restate/e2e/functions/externalcall/RandomNumberListGeneratorService.java
+++ b/functions/externalcall/impl/src/main/java/dev/restate/e2e/functions/externalcall/RandomNumberListGeneratorService.java
@@ -33,7 +33,7 @@ public class RandomNumberListGeneratorService
 
     byte[] sortedNumbersJson =
         RestateContext.current()
-            .asyncCall(
+            .callback(
                 byte[].class,
                 replyId -> {
                   try {

--- a/functions/externalcall/impl/src/main/java/dev/restate/e2e/functions/externalcall/ReplierService.java
+++ b/functions/externalcall/impl/src/main/java/dev/restate/e2e/functions/externalcall/ReplierService.java
@@ -1,7 +1,7 @@
 package dev.restate.e2e.functions.externalcall;
 
 import com.google.protobuf.Empty;
-import dev.restate.sdk.ReplyIdentifier;
+import dev.restate.sdk.CallbackIdentifier;
 import dev.restate.sdk.RestateContext;
 import io.grpc.stub.StreamObserver;
 import org.apache.logging.log4j.LogManager;
@@ -16,8 +16,8 @@ public class ReplierService extends ReplierGrpc.ReplierImplBase {
       Reply request, StreamObserver<Empty> responseObserver) {
     LOG.info("Received request " + request);
     RestateContext.current()
-        .reply(
-            ReplyIdentifier.fromBytes(request.getReplyIdentifier().toByteArray()),
+        .completeCallback(
+            CallbackIdentifier.fromBytes(request.getReplyIdentifier().toByteArray()),
             request.getPayload().toByteArray());
 
     responseObserver.onNext(Empty.getDefaultInstance());

--- a/functions/utils/src/main/java/dev/restate/e2e/functions/utils/NumberSortHttpServerUtils.java
+++ b/functions/utils/src/main/java/dev/restate/e2e/functions/utils/NumberSortHttpServerUtils.java
@@ -2,7 +2,7 @@ package dev.restate.e2e.functions.utils;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import dev.restate.sdk.ReplyIdentifier;
+import dev.restate.sdk.CallbackIdentifier;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.http.HttpClient;
@@ -17,12 +17,12 @@ public class NumberSortHttpServerUtils {
   private static final ObjectMapper objectMapper = new ObjectMapper();
 
   public static HttpResponse<Void> sendSortNumbersRequest(
-      ReplyIdentifier replyId, List<Integer> numbers) throws Exception {
+      CallbackIdentifier replyId, List<Integer> numbers) throws Exception {
     return HttpClient.newHttpClient()
         .send(prepareRequest(replyId, numbers), BodyHandlers.discarding());
   }
 
-  private static HttpRequest prepareRequest(ReplyIdentifier replyId, List<Integer> numbers)
+  private static HttpRequest prepareRequest(CallbackIdentifier replyId, List<Integer> numbers)
       throws URISyntaxException, JsonProcessingException {
     return HttpRequest.newBuilder()
         .uri(new URI(System.getenv("HTTP_SERVER_ADDRESS")))


### PR DESCRIPTION
And replaced with invoke and fireAndForget. See https://github.com/restatedev/java-sdk/pull/65