### PR TITLE
Test 404 propagation for internal function calls

### DIFF
--- a/functions/errors/contract/src/main/proto/errors.proto
+++ b/functions/errors/contract/src/main/proto/errors.proto
@@ -14,6 +14,7 @@ service FailingService {
   rpc Fail (ErrorMessage) returns (google.protobuf.Empty);
   rpc FailAndHandle (ErrorMessage) returns (ErrorMessage);
   rpc InvokeExternalAndHandleFailure(FailRequest) returns (ErrorMessage);
+  rpc HandleNotFound (FailRequest) returns (ErrorMessage);
 }
 
 message FailRequest {

--- a/tests/src/test/kotlin/dev/restate/e2e/ErrorsTest.kt
+++ b/tests/src/test/kotlin/dev/restate/e2e/ErrorsTest.kt
@@ -67,4 +67,13 @@ class ErrorsTest {
         .extracting(ErrorMessage::getErrorMessage)
         .isEqualTo("begin:external_call:internal_call")
   }
+
+  @Test
+  fun propagate404(@InjectBlockingStub stub: FailingServiceBlockingStub) {
+    assertThat(
+            stub.handleNotFound(
+                FailRequest.newBuilder().setKey(UUID.randomUUID().toString()).build()))
+        .extracting(ErrorMessage::getErrorMessage)
+        .isEqualTo("notfound")
+  }
 }


### PR DESCRIPTION
See https://github.com/restatedev/runtime/pull/181