### PR TITLE
Enable license check and report generation via Gradle License Report plugin

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,6 +6,7 @@ plugins {
   kotlin("jvm") version "1.6.20"
   java
   alias(libs.plugins.spotless)
+  id("com.github.jk1.dependency-license-report") version "2.0"
 }
 
 val restateVersion = libs.versions.restate.get()
@@ -20,6 +21,7 @@ allprojects {
   apply(plugin = "java")
   apply(plugin = "kotlin")
   apply(plugin = "com.diffplug.spotless")
+  apply(plugin = "com.github.jk1.dependency-license-report")
 
   version = restateVersion
 
@@ -27,6 +29,29 @@ allprojects {
     kotlin { ktfmt() }
     kotlinGradle { ktfmt() }
     java { googleJavaFormat() }
+  }
+
+  tasks { check { dependsOn(checkLicense) } }
+
+  licenseReport {
+    renderers = arrayOf(com.github.jk1.license.render.CsvReportRenderer())
+
+    excludeBoms = true
+
+    excludes =
+        arrayOf(
+            "io.vertx:vertx-stack-depchain", // Vertx bom file
+            "org.jetbrains.kotlinx:kotlinx-coroutines-core", // Kotlinx coroutines bom file
+            "dev.restate.sdk:java-sdk", // Our own dependency has no license yet
+            "java-sdk:sdk", // Exclude java-sdk from composite build (dev.restate.sdk:java-sdk gets
+            // replace by java-sdk:sdk)
+            )
+
+    allowedLicensesFile = file("$rootDir/config/allowed-licenses.json")
+    filters =
+        arrayOf(
+            com.github.jk1.license.filter.LicenseBundleNormalizer(
+                "$rootDir/config/license-normalizer-bundle.json", true))
   }
 }
 

--- a/config/allowed-licenses.json
+++ b/config/allowed-licenses.json
@@ -1,0 +1,48 @@
+{
+  "allowedLicenses": [
+    {
+      "moduleLicense": "Apache License, Version 2.0"
+    },
+    {
+      "moduleLicense": "The MIT License (MIT)"
+    },
+    {
+      "moduleLicense": "The 2-Clause BSD License"
+    },
+    {
+      "moduleLicense": "The 3-Clause BSD License"
+    },
+    # EPLv1 is ok, because we only include the binary
+    {
+      "moduleLicense": "Eclipse Public License - v 1.0",
+      "moduleName": "junit:junit",
+      "moduleVersion": "4.13.2"
+    },
+    # EPLv2 is ok, because we only include the binary
+    {
+      "moduleLicense": "Eclipse Public License - v 2.0",
+      "moduleName": "org.junit.jupiter:junit-jupiter-api",
+      "moduleVersion": "5.8.2"
+    },
+    # EPLv2 is ok, because we only include the binary
+    {
+      "moduleLicense": "Eclipse Public License - v 2.0",
+      "moduleName": "org.junit.platform:junit-platform-commons",
+      "moduleVersion": "1.8.2"
+    },
+    # Our own dependencies have no license yet
+    {
+      "moduleLicense": null,
+      "moduleName": "dev.restate.sdk:java-sdk"
+    },
+    # This module results from local composite builds where dev.restate.sdk:java-sdk gets substituted via java-sdk:sdk
+    {
+      "moduleLicense": null,
+      "moduleName": "java-sdk:sdk"
+    },
+    {
+      "moduleLicense": null,
+      "moduleName": "restate-e2e:contracts"
+    }
+  ]
+}

--- a/config/license-normalizer-bundle.json
+++ b/config/license-normalizer-bundle.json
@@ -1,0 +1,35 @@
+{
+  "bundles": [
+    {
+      "bundleName": "Apache-2.0",
+      "licenseName": "Apache License, Version 2.0",
+      "licenseUrl": "https://www.apache.org/licenses/LICENSE-2.0"
+    },
+    {
+      "bundleName": "MIT",
+      "licenseName": "The MIT License (MIT)"
+    }
+  ],
+  "transformationRules": [
+    {
+      "bundleName": "Apache-2.0",
+      "licenseNamePattern": ".*The Apache Software License, Version 2\\.0.*"
+    },
+    {
+      "bundleName": "Apache-2.0",
+      "licenseNamePattern": "Apache[ |-|_]2.*"
+    },
+    {
+      "bundleName": "Apache-2.0",
+      "licenseNamePattern": "ASL 2\\.0"
+    },
+    {
+      "bundleName": "Apache-2.0",
+      "licenseNamePattern": ".*Apache License,?( Version)? 2.*"
+    },
+    {
+      "bundleName": "MIT",
+      "licenseNamePattern": ".*MIT License.*"
+    }
+  ]
+}


### PR DESCRIPTION
To run the license check run checkLicense. To generate the license report run generateLicenseReport. This also works for the subprojects.

This fixes #75.