### PR TITLE
Disable infinite retries for tests about failure propagation

### DIFF
--- a/tests/src/test/kotlin/dev/restate/e2e/Containers.kt
+++ b/tests/src/test/kotlin/dev/restate/e2e/Containers.kt
@@ -70,6 +70,7 @@ object Containers {
       javaServicesContainer("java-errors", FailingServiceGrpc.SERVICE_NAME)
           .withEnv(
               "HTTP_SERVER_ADDRESS", "http://${EXTERNALCALL_HTTP_SERVER_CONTAINER_SPEC.first}:8080")
+          .withRegistrationOptions(RegistrationOptions(retryPolicy = RetryPolicy.None))
           .build()
 
   // -- Node containers
@@ -93,6 +94,7 @@ object Containers {
 
   val NODE_ERRORS_FUNCTION_SPEC =
       nodeServicesContainer("node-errors", FailingServiceGrpc.SERVICE_NAME)
+          .withRegistrationOptions(RegistrationOptions(retryPolicy = RetryPolicy.None))
 
   // -- Verification test container (source https://github.com/restatedev/restate-verification)
 

--- a/tests/src/test/kotlin/dev/restate/e2e/ErrorsTest.kt
+++ b/tests/src/test/kotlin/dev/restate/e2e/ErrorsTest.kt
@@ -5,6 +5,7 @@ import dev.restate.e2e.functions.counter.CounterProto
 import dev.restate.e2e.functions.errors.ErrorsProto.ErrorMessage
 import dev.restate.e2e.functions.errors.ErrorsProto.FailRequest
 import dev.restate.e2e.functions.errors.FailingServiceGrpc.FailingServiceBlockingStub
+import dev.restate.e2e.utils.FunctionSpec
 import dev.restate.e2e.utils.InjectBlockingStub
 import dev.restate.e2e.utils.RestateDeployer
 import dev.restate.e2e.utils.RestateDeployerExtension
@@ -29,7 +30,11 @@ class JavaErrorsTest : BaseErrorsTest() {
                 .withEnv(Containers.getRestateEnvironment())
                 .withServiceEndpoint(Containers.JAVA_ERRORS_FUNCTION_SPEC)
                 .withServiceEndpoint(Containers.JAVA_EXTERNALCALL_FUNCTION_SPEC)
-                .withServiceEndpoint(Containers.JAVA_COUNTER_FUNCTION_SPEC)
+                .withServiceEndpoint(
+                    Containers.JAVA_COUNTER_FUNCTION_SPEC.copy(
+                        registrationOptions =
+                            FunctionSpec.RegistrationOptions(
+                                retryPolicy = FunctionSpec.RetryPolicy.None)))
                 .withContainer(Containers.EXTERNALCALL_HTTP_SERVER_CONTAINER_SPEC)
                 .build())
   }
@@ -61,7 +66,11 @@ class NodeErrorsTest : BaseErrorsTest() {
             RestateDeployer.Builder()
                 .withEnv(Containers.getRestateEnvironment())
                 .withServiceEndpoint(Containers.NODE_ERRORS_FUNCTION_SPEC)
-                .withServiceEndpoint(Containers.NODE_COUNTER_FUNCTION_SPEC)
+                .withServiceEndpoint(
+                    Containers.NODE_COUNTER_FUNCTION_SPEC.copy(
+                        registrationOptions =
+                            FunctionSpec.RegistrationOptions(
+                                retryPolicy = FunctionSpec.RetryPolicy.None)))
                 .build())
   }
 }

--- a/tests/src/test/kotlin/dev/restate/e2e/NonDeterminismTest.kt
+++ b/tests/src/test/kotlin/dev/restate/e2e/NonDeterminismTest.kt
@@ -7,6 +7,7 @@ import dev.restate.e2e.functions.counter.CounterProto
 import dev.restate.e2e.functions.nondeterminism.NonDeterminismProto.NonDeterministicRequest
 import dev.restate.e2e.functions.nondeterminism.NonDeterministicServiceGrpc
 import dev.restate.e2e.utils.*
+import dev.restate.e2e.utils.FunctionSpec.*
 import io.grpc.*
 import io.grpc.stub.ClientCalls
 import java.util.*
@@ -30,9 +31,11 @@ class JavaNonDeterminismTest : NonDeterminismTest() {
                 .withEnv(Containers.getRestateEnvironment())
                 .withServiceEndpoint(
                     Containers.javaServicesContainer(
-                        "java-non-determinism",
-                        NonDeterministicServiceGrpc.SERVICE_NAME,
-                        CounterGrpc.SERVICE_NAME))
+                            "java-non-determinism",
+                            NonDeterministicServiceGrpc.SERVICE_NAME,
+                            CounterGrpc.SERVICE_NAME)
+                        .withRegistrationOptions(
+                            RegistrationOptions(retryPolicy = RetryPolicy.None)))
                 .build())
   }
 }
@@ -47,9 +50,11 @@ class NodeNonDeterminismTest : NonDeterminismTest() {
                 .withEnv(Containers.getRestateEnvironment())
                 .withServiceEndpoint(
                     Containers.nodeServicesContainer(
-                        "node-non-determinism",
-                        NonDeterministicServiceGrpc.SERVICE_NAME,
-                        CounterGrpc.SERVICE_NAME))
+                            "node-non-determinism",
+                            NonDeterministicServiceGrpc.SERVICE_NAME,
+                            CounterGrpc.SERVICE_NAME)
+                        .withRegistrationOptions(
+                            RegistrationOptions(retryPolicy = RetryPolicy.None)))
                 .build())
   }
 }


### PR DESCRIPTION
https://github.com/restatedev/restate/pull/422 will enable infinite retries, but this is a behavior we don't want for these tests.