### PR TITLE
Add `TYPESCRIPT_SDK_LOCAL_BUILD` and rename `E2E_LOCAL_BUILD` to `JAVA_SDK_LOCAL_BUILD`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,8 @@ This will populate your local image registry with the various function container
 ### How to test Java SDK changes
 
 In order to test local changes to the `sdk-java`, you need to check it out under `../sdk-java`.
-When building the `e2e` project you have to set the environment variable `E2E_LOCAL_BUILD=true` to include `sdk-java` as a composite build and substitute the `dev.restate.sdk:sdk-java` dependency with it.
+When building the `e2e` project you have to set the environment variable `JAVA_SDK_LOCAL_BUILD=true` 
+to include `sdk-java` as a composite build and substitute the `dev.restate.sdk:sdk-java` dependency with it.
 The build will fail if Gradle cannot find the `sdk-java` project.
 
 ### How to test Typescript SDK changes
@@ -53,6 +54,8 @@ gradle :services:node-services:installLocalTypescriptSdk
 ```
 
 This will build the Typescript SDK, pack it with `npm pack`, and copy it over to the node-services directory and install it.
+
+You can include `gradle :services:node-services:installLocalTypescriptSdk` in the build process by setting `TYPESCRIPT_SDK_LOCAL_BUILD=true`.
 
 ### How to test Restate runtime changes
 

--- a/services/node-services/build.gradle.kts
+++ b/services/node-services/build.gradle.kts
@@ -12,6 +12,11 @@ tasks.register("generateProto") {
 
 tasks.register<Copy>("prepareDockerBuild") {
   dependsOn("generateProto")
+
+  if (!System.getenv("TYPESCRIPT_SDK_LOCAL_BUILD").isNullOrEmpty()) {
+    dependsOn("installLocalTypescriptSdk")
+  }
+
   from(".") {
     include("src/**")
     into("src")

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -85,7 +85,7 @@ dependencyResolutionManagement {
 }
 
 // Include composite build for easier local testing
-if (!System.getenv("E2E_LOCAL_BUILD").isNullOrEmpty()) {
+if (!System.getenv("JAVA_SDK_LOCAL_BUILD").isNullOrEmpty()) {
   includeBuild("../sdk-java") {
     dependencySubstitution {
       substitute(module("dev.restate.sdk:sdk-core")).using(project(":sdk-core"))


### PR DESCRIPTION
With those in place, we can easily setup the CI in the sdk repos.