### PR TITLE
Reintroduce the SideEffect flush test

### DIFF
--- a/contracts/src/main/proto/side_effect.proto
+++ b/contracts/src/main/proto/side_effect.proto
@@ -1,0 +1,21 @@
+syntax = "proto3";
+
+option java_package = "dev.restate.e2e.services.sideeffect";
+option java_outer_classname = "SideEffectProto";
+
+import "google/protobuf/empty.proto";
+import "dev/restate/ext.proto";
+
+package sideeffect;
+
+service SideEffect {
+  option (dev.restate.ext.service_type) = UNKEYED;
+
+  rpc InvokeSideEffects(InvokeSideEffectsRequest) returns (InvokeSideEffectsResult);
+}
+
+message InvokeSideEffectsRequest {}
+
+message InvokeSideEffectsResult {
+  int32 non_deterministic_invocation_count = 1;
+}

--- a/services/java-services/src/main/java/dev/restate/e2e/services/Main.java
+++ b/services/java-services/src/main/java/dev/restate/e2e/services/Main.java
@@ -17,6 +17,8 @@ import dev.restate.e2e.services.externalcall.ReplierService;
 import dev.restate.e2e.services.nondeterminism.NonDeterministicService;
 import dev.restate.e2e.services.nondeterminism.NonDeterministicServiceGrpc;
 import dev.restate.e2e.services.receiver.ReceiverGrpc;
+import dev.restate.e2e.services.sideeffect.SideEffectGrpc;
+import dev.restate.e2e.services.sideeffect.SideEffectService;
 import dev.restate.e2e.services.singletoncounter.SingletonCounterGrpc;
 import dev.restate.sdk.vertx.RestateHttpEndpointBuilder;
 import io.vertx.core.Vertx;
@@ -60,6 +62,9 @@ public class Main {
           break;
         case NonDeterministicServiceGrpc.SERVICE_NAME:
           restateHttpEndpointBuilder.withService(new NonDeterministicService());
+          break;
+        case SideEffectGrpc.SERVICE_NAME:
+          restateHttpEndpointBuilder.withService(new SideEffectService());
           break;
       }
     }

--- a/services/java-services/src/main/java/dev/restate/e2e/services/sideeffect/SideEffectService.java
+++ b/services/java-services/src/main/java/dev/restate/e2e/services/sideeffect/SideEffectService.java
@@ -1,0 +1,29 @@
+package dev.restate.e2e.services.sideeffect;
+
+import dev.restate.sdk.blocking.RestateBlockingService;
+import dev.restate.sdk.blocking.RestateContext;
+import io.grpc.stub.StreamObserver;
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class SideEffectService extends SideEffectGrpc.SideEffectImplBase
+    implements RestateBlockingService {
+
+  @Override
+  public void invokeSideEffects(
+      SideEffectProto.InvokeSideEffectsRequest request,
+      StreamObserver<SideEffectProto.InvokeSideEffectsResult> responseObserver) {
+    RestateContext ctx = restateContext();
+
+    AtomicInteger invokedSideEffects = new AtomicInteger(0);
+
+    ctx.sideEffect(() -> invokedSideEffects.incrementAndGet());
+    ctx.sideEffect(() -> invokedSideEffects.incrementAndGet());
+    ctx.sideEffect(() -> invokedSideEffects.incrementAndGet());
+
+    responseObserver.onNext(
+        SideEffectProto.InvokeSideEffectsResult.newBuilder()
+            .setNonDeterministicInvocationCount(invokedSideEffects.intValue())
+            .build());
+    responseObserver.onCompleted();
+  }
+}

--- a/services/node-services/src/app.ts
+++ b/services/node-services/src/app.ts
@@ -8,6 +8,7 @@ import { protoMetadata as errorsProtoMetadata } from "./generated/errors";
 import { protoMetadata as nonDeterminismProtoMetadata } from "./generated/non_determinism";
 import { protoMetadata as verifierProtoMetadata } from "./generated/verifier";
 import { protoMetadata as interpreterProtoMetadata } from "./generated/interpreter";
+import { protoMetadata as sideEffectProtoMetadata } from "./generated/side_effect";
 import { CounterService, CounterServiceFQN } from "./counter";
 import { ListService, ListServiceFQN } from "./collections";
 import { FailingService, FailingServiceFQN } from "./errors";
@@ -23,6 +24,7 @@ import {
   CommandInterpreterService,
   CommandInterpreterServiceFQN,
 } from "./interpreter";
+import { SideEffectService, SideEffectServiceFQN } from "./side_effect";
 
 let serverBuilder = restate.createServer();
 
@@ -97,6 +99,14 @@ const services = new Map<string, restate.ServiceOpts>([
       descriptor: interpreterProtoMetadata,
       service: "CommandInterpreter",
       instance: new CommandInterpreterService(),
+    },
+  ],
+  [
+    SideEffectServiceFQN,
+    {
+      descriptor: sideEffectProtoMetadata,
+      service: "SideEffect",
+      instance: new SideEffectService(),
     },
   ],
 ]);

--- a/services/node-services/src/side_effect.ts
+++ b/services/node-services/src/side_effect.ts
@@ -1,0 +1,30 @@
+import * as restate from "@restatedev/restate-sdk";
+
+import {
+  InvokeSideEffectsResult,
+  SideEffect,
+  protobufPackage,
+} from "./generated/side_effect";
+
+export const SideEffectServiceFQN = protobufPackage + ".SideEffect";
+
+export class SideEffectService implements SideEffect {
+  async invokeSideEffects(): Promise<InvokeSideEffectsResult> {
+    console.log("invokeSideEffects");
+    const ctx = restate.useContext(this);
+
+    let invocationCount = 0;
+
+    await ctx.sideEffect<void>(async () => {
+      invocationCount++;
+    });
+    await ctx.sideEffect<void>(async () => {
+      invocationCount++;
+    });
+    await ctx.sideEffect<void>(async () => {
+      invocationCount++;
+    });
+
+    return { nonDeterministicInvocationCount: invocationCount };
+  }
+}

--- a/tests/src/test/kotlin/dev/restate/e2e/SideEffectTest.kt
+++ b/tests/src/test/kotlin/dev/restate/e2e/SideEffectTest.kt
@@ -1,0 +1,57 @@
+package dev.restate.e2e
+
+import dev.restate.e2e.services.sideeffect.SideEffectGrpc
+import dev.restate.e2e.services.sideeffect.SideEffectGrpc.SideEffectBlockingStub
+import dev.restate.e2e.services.sideeffect.SideEffectProto
+import dev.restate.e2e.utils.InjectBlockingStub
+import dev.restate.e2e.utils.RestateDeployer
+import dev.restate.e2e.utils.RestateDeployerExtension
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Disabled
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Tag
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.RegisterExtension
+
+@Tag("only-always-suspending")
+class JavaSideEffectTest : BaseSideEffectTest() {
+  companion object {
+    @RegisterExtension
+    val deployerExt: RestateDeployerExtension =
+        RestateDeployerExtension(
+            RestateDeployer.Builder()
+                .withEnv(Containers.getRestateEnvironment())
+                .withServiceEndpoint(
+                    Containers.javaServicesContainer(
+                        "java-side-effect", SideEffectGrpc.SERVICE_NAME))
+                .build())
+  }
+}
+
+@Tag("only-always-suspending")
+@Disabled("https://github.com/restatedev/sdk-typescript/issues/82")
+class NodeSideEffectTest : BaseSideEffectTest() {
+  companion object {
+    @RegisterExtension
+    val deployerExt: RestateDeployerExtension =
+        RestateDeployerExtension(
+            RestateDeployer.Builder()
+                .withEnv(Containers.getRestateEnvironment())
+                .withServiceEndpoint(
+                    Containers.nodeServicesContainer(
+                        "node-side-effect", SideEffectGrpc.SERVICE_NAME))
+                .build())
+  }
+}
+
+abstract class BaseSideEffectTest {
+  @DisplayName("Side effect should wait on acknowledgements")
+  @Test
+  fun sideEffectFlush(@InjectBlockingStub sideEffectStub: SideEffectBlockingStub) {
+    assertThat(
+            sideEffectStub.invokeSideEffects(
+                SideEffectProto.InvokeSideEffectsRequest.newBuilder().build()))
+        .extracting { it.nonDeterministicInvocationCount }
+        .isEqualTo(1)
+  }
+}


### PR DESCRIPTION
This was previously removed when converting this repo to the new runtime