### PR TITLE
Add test for unawaited sync call to e2e

### DIFF
--- a/tests/src/test/kotlin/dev/restate/e2e/node/VerificationTest.kt
+++ b/tests/src/test/kotlin/dev/restate/e2e/node/VerificationTest.kt
@@ -1,19 +1,16 @@
 package dev.restate.e2e.node
 
 import dev.restate.e2e.Containers
+import dev.restate.e2e.services.verification.interpreter.*
 import dev.restate.e2e.services.verification.interpreter.CommandInterpreterGrpc.CommandInterpreterBlockingStub
-import dev.restate.e2e.services.verification.interpreter.InterpreterProto.CallRequest
-import dev.restate.e2e.services.verification.interpreter.InterpreterProto.Command
-import dev.restate.e2e.services.verification.interpreter.InterpreterProto.Command.AsyncCall
-import dev.restate.e2e.services.verification.interpreter.InterpreterProto.Command.AsyncCallAwait
-import dev.restate.e2e.services.verification.interpreter.InterpreterProto.Command.Sleep
-import dev.restate.e2e.services.verification.interpreter.InterpreterProto.Commands
-import dev.restate.e2e.services.verification.interpreter.InterpreterProto.Key
+import dev.restate.e2e.services.verification.interpreter.CommandKt.asyncCall
+import dev.restate.e2e.services.verification.interpreter.CommandKt.asyncCallAwait
+import dev.restate.e2e.services.verification.interpreter.CommandKt.sleep
 import dev.restate.e2e.services.verification.interpreter.InterpreterProto.TestParams
 import dev.restate.e2e.services.verification.verifier.CommandVerifierGrpc.CommandVerifierBlockingStub
-import dev.restate.e2e.services.verification.verifier.VerifierProto
-import dev.restate.e2e.services.verification.verifier.VerifierProto.ExecuteRequest
-import dev.restate.e2e.services.verification.verifier.VerifierProto.VerificationRequest
+import dev.restate.e2e.services.verification.verifier.clearRequest
+import dev.restate.e2e.services.verification.verifier.executeRequest
+import dev.restate.e2e.services.verification.verifier.verificationRequest
 import dev.restate.e2e.utils.*
 import io.grpc.StatusRuntimeException
 import java.util.concurrent.TimeUnit
@@ -65,20 +62,18 @@ class VerificationTest {
             .pollInterval(POLL_INTERVAL)
             .atMost(MAX_POLL_TIME)
             .ignoreException(StatusRuntimeException::class)
-            .untilAsserted {
-              this.verify(VerificationRequest.newBuilder().setParams(testParams).build())
-            }
+            .untilAsserted { this.verify(verificationRequest { params = testParams }) }
   }
 
   @Timeout(value = 1, unit = TimeUnit.MINUTES)
   @Test
   fun simple(@InjectBlockingStub verifier: CommandVerifierBlockingStub) {
     val testParams = testParams()
+    verifier.execute(executeRequest { params = testParams })
 
-    verifier.execute(ExecuteRequest.newBuilder().setParams(testParams).build())
     verifier.awaitVerify(testParams)
 
-    verifier.clear(VerifierProto.ClearRequest.newBuilder().setParams(testParams).build())
+    verifier.clear(clearRequest { params = testParams })
   }
 
   @Timeout(value = 1, unit = TimeUnit.MINUTES)
@@ -90,7 +85,7 @@ class VerificationTest {
   ) {
     val testParams = testParams()
 
-    verifier.execute(ExecuteRequest.newBuilder().setParams(testParams).build())
+    verifier.execute(executeRequest { params = testParams })
 
     Thread.sleep(Random.nextInt(1..10).seconds.inWholeMilliseconds)
 
@@ -98,7 +93,7 @@ class VerificationTest {
 
     verifier.awaitVerify(testParams)
 
-    verifier.clear(VerifierProto.ClearRequest.newBuilder().setParams(testParams).build())
+    verifier.clear(clearRequest { params = testParams })
   }
 
   @Timeout(value = 1, unit = TimeUnit.MINUTES)
@@ -110,7 +105,7 @@ class VerificationTest {
   ) {
     val testParams = testParams()
 
-    verifier.execute(ExecuteRequest.newBuilder().setParams(testParams).build())
+    verifier.execute(executeRequest { params = testParams })
 
     Thread.sleep(Random.nextInt(1..10).seconds.inWholeMilliseconds)
 
@@ -118,7 +113,7 @@ class VerificationTest {
 
     verifier.awaitVerify(testParams)
 
-    verifier.clear(VerifierProto.ClearRequest.newBuilder().setParams(testParams).build())
+    verifier.clear(clearRequest { params = testParams })
   }
 
   @Timeout(value = 1, unit = TimeUnit.MINUTES)
@@ -129,7 +124,7 @@ class VerificationTest {
   ) {
     val testParams = testParams()
 
-    verifier.execute(ExecuteRequest.newBuilder().setParams(testParams).build())
+    verifier.execute(executeRequest { params = testParams })
 
     Thread.sleep(Random.nextInt(1..10).seconds.inWholeMilliseconds)
 
@@ -137,7 +132,7 @@ class VerificationTest {
 
     verifier.awaitVerify(testParams)
 
-    verifier.clear(VerifierProto.ClearRequest.newBuilder().setParams(testParams).build())
+    verifier.clear(clearRequest { params = testParams })
   }
 
   @Timeout(value = 1, unit = TimeUnit.MINUTES)
@@ -148,7 +143,7 @@ class VerificationTest {
   ) {
     val testParams = testParams()
 
-    verifier.execute(ExecuteRequest.newBuilder().setParams(testParams).build())
+    verifier.execute(executeRequest { params = testParams })
 
     Thread.sleep(Random.nextInt(1..10).seconds.inWholeMilliseconds)
 
@@ -156,60 +151,57 @@ class VerificationTest {
 
     verifier.awaitVerify(testParams)
 
-    verifier.clear(VerifierProto.ClearRequest.newBuilder().setParams(testParams).build())
+    verifier.clear(clearRequest { params = testParams })
   }
 
-  @Timeout(value = 1, unit = TimeUnit.MINUTES)
+  @Timeout(value = 2, unit = TimeUnit.MINUTES)
   @DisplayName("Suspending or returning with an unawaited blocked syncCall should not deadlock")
   @Test
   fun unawaitedSelfCall(@InjectBlockingStub interpreter: CommandInterpreterBlockingStub) {
-    val params = TestParams.newBuilder().build()
-    val key = Key.newBuilder().setParams(params).setTarget(1).build()
-    val commands =
-        Commands.newBuilder()
-            .addCommand(
-                Command.newBuilder()
-                    .setAsyncCall(
-                        AsyncCall.newBuilder()
-                            .setTarget(2) // won't deadlock
-                            .setCallId(1)
-                            .setCommands(
-                                Commands.newBuilder()
-                                    .addCommand(
-                                        Command.newBuilder()
-                                            .setSleep(Sleep.newBuilder().setMilliseconds(5000)))
-                                    .build())
-                            .build())
-                    .build())
-            .addCommand(
-                Command.newBuilder()
-                    .setAsyncCall(
-                        AsyncCall.newBuilder()
-                            .setTarget(1) // would deadlock if awaited, but we don't await it
-                            .build())
-                    .build())
-            .addCommand(
-                Command.newBuilder()
-                    .setAsyncCallAwait(
-                        AsyncCallAwait.newBuilder()
-                            .setCallId(1) // waits 5 seconds so we trigger the suspend timeout
-                            .build()))
-            .build()
-    interpreter.call(CallRequest.newBuilder().setKey(key).setCommands(commands).build())
+    interpreter.call(
+        callRequest {
+          key = key {
+            params = testParams {}
+            target = 1
+          }
+          commands = commands {
+            command.addAll(
+                listOf(
+                    command {
+                      asyncCall = asyncCall {
+                        target = 2 // won't deadlock
+                        callId = 1
+                        commands = commands {
+                          command.add(command { sleep = sleep { milliseconds = 35000 } })
+                        }
+                      }
+                    },
+                    command {
+                      asyncCall = asyncCall {
+                        target = 1 // would deadlock if awaited, but we don't await it
+                      }
+                    },
+                    command {
+                      asyncCallAwait = asyncCallAwait {
+                        callId = 1 // waits 5 seconds so we trigger the suspend timeout
+                      }
+                    }))
+          }
+        })
   }
 
   private fun testParams(): TestParams {
-    var seed = System.getenv(E2E_VERIFICATION_SEED_ENV)
-    if (seed.isNullOrEmpty()) {
-      seed = generateAlphanumericString(16)
+    var testSeed = System.getenv(E2E_VERIFICATION_SEED_ENV)
+    if (testSeed.isNullOrEmpty()) {
+      testSeed = generateAlphanumericString(16)
     }
 
-    logger.info("Using seed {}", seed)
-    return TestParams.newBuilder()
-        .setSeed(seed)
-        .setWidth(3)
-        .setDepth(14)
-        .setMaxSleepMillis(5.seconds.inWholeMilliseconds.toInt())
-        .build()
+    logger.info("Using seed {}", testSeed)
+    return dev.restate.e2e.services.verification.interpreter.testParams {
+      seed = testSeed
+      width = 3
+      depth = 14
+      maxSleepMillis = 5.seconds.inWholeMilliseconds.toInt()
+    }
   }
 }


### PR DESCRIPTION
This particular case has caused verification test failures twice. Its tests a tricky area of the sdk, which may be simplified during the sdk refactor, but its still worth us testing for explicitly