### PR TITLE
Bump verification width to 4

### DIFF
--- a/tests/src/test/kotlin/dev/restate/e2e/node/VerificationTest.kt
+++ b/tests/src/test/kotlin/dev/restate/e2e/node/VerificationTest.kt
@@ -61,7 +61,7 @@ class VerificationTest {
             }
   }
 
-  @Timeout(value = 1, unit = TimeUnit.MINUTES)
+  @Timeout(value = 2, unit = TimeUnit.MINUTES)
   @Test
   fun simple(@InjectBlockingStub verifier: CommandVerifierBlockingStub) {
     val testParams = testParams()
@@ -72,7 +72,7 @@ class VerificationTest {
     verifier.clear(VerifierProto.ClearRequest.newBuilder().setParams(testParams).build())
   }
 
-  @Timeout(value = 1, unit = TimeUnit.MINUTES)
+  @Timeout(value = 2, unit = TimeUnit.MINUTES)
   @Test
   fun killingTheServiceEndpoint(
       @InjectBlockingStub verifier: CommandVerifierBlockingStub,
@@ -92,7 +92,7 @@ class VerificationTest {
     verifier.clear(VerifierProto.ClearRequest.newBuilder().setParams(testParams).build())
   }
 
-  @Timeout(value = 1, unit = TimeUnit.MINUTES)
+  @Timeout(value = 2, unit = TimeUnit.MINUTES)
   @Test
   fun stoppingTheServiceEndpoint(
       @InjectBlockingStub verifier: CommandVerifierBlockingStub,
@@ -112,7 +112,7 @@ class VerificationTest {
     verifier.clear(VerifierProto.ClearRequest.newBuilder().setParams(testParams).build())
   }
 
-  @Timeout(value = 1, unit = TimeUnit.MINUTES)
+  @Timeout(value = 2, unit = TimeUnit.MINUTES)
   @Test
   fun killingTheRuntime(
       @InjectBlockingStub verifier: CommandVerifierBlockingStub,
@@ -131,7 +131,7 @@ class VerificationTest {
     verifier.clear(VerifierProto.ClearRequest.newBuilder().setParams(testParams).build())
   }
 
-  @Timeout(value = 1, unit = TimeUnit.MINUTES)
+  @Timeout(value = 2, unit = TimeUnit.MINUTES)
   @Test
   fun stoppingTheRuntime(
       @InjectBlockingStub verifier: CommandVerifierBlockingStub,


### PR DESCRIPTION
This matches the long running tests, but not the runtime repo. I think this is a sensible default, as the long running ones have caught lots of stuff

Part of #145