### PR TITLE
Update e2e to work with restatedev/restate#630

### DIFF
--- a/tests/build.gradle.kts
+++ b/tests/build.gradle.kts
@@ -49,7 +49,7 @@ tasks {
     environment =
         environment +
             baseRestateEnvironment(name) +
-            mapOf("RESTATE_WORKER__INVOKER__SUSPENSION_TIMEOUT" to "0s")
+            mapOf("RESTATE_WORKER__INVOKER__INACTIVITY_TIMEOUT" to "0s")
 
     useJUnitPlatform {
       // Run all the tests with always-suspending or only-always-suspending tag


### PR DESCRIPTION
This commit updates the e2e test to use the renamed inactivity_timeout.

This fixes #179.