### PR TITLE
Adjust Node e2e tests to new error handling

### DIFF
--- a/services/node-services/src/counter.ts
+++ b/services/node-services/src/counter.ts
@@ -38,7 +38,7 @@ export class CounterService implements Counter {
   async addThenFail(request: CounterAddRequest): Promise<Empty> {
     await this.add(request);
 
-    throw new Error(request.counterName);
+    throw new restate.TerminalError(request.counterName);
   }
 
   async get(request: CounterRequest): Promise<GetResponse> {

--- a/services/node-services/src/errors.ts
+++ b/services/node-services/src/errors.ts
@@ -13,7 +13,7 @@ export const FailingServiceFQN = protobufPackage + ".FailingService";
 export class FailingService implements IFailingService {
   fail(request: ErrorMessage): Promise<Empty> {
     console.log("fail: " + JSON.stringify(request));
-    throw new Error(request.errorMessage);
+    throw new restate.TerminalError(request.errorMessage);
   }
 
   async failAndHandle(request: ErrorMessage): Promise<ErrorMessage> {
@@ -39,6 +39,6 @@ export class FailingService implements IFailingService {
   }
 
   invokeExternalAndHandleFailure(): Promise<ErrorMessage> {
-    throw new Error("Method not implemented.");
+    throw new restate.TerminalError("Method not implemented.");
   }
 }


### PR DESCRIPTION
Adjust Node e2e tests to use `TerminalError` when creating failures that should not be retried.