### PR TITLE
Add explicit return type annotation to avoid circular reference

### DIFF
--- a/services/node-services/src/handler_api.ts
+++ b/services/node-services/src/handler_api.ts
@@ -3,10 +3,10 @@ import * as restate from "@restatedev/restate-sdk";
 export const HandlerAPIEchoTestFQN = "handlerapi.HandlerAPIEchoTest";
 
 // These two handlers just test the correct propagation of the input message in the output
-const echo = (ctx: restate.RpcContext, msg: any) => {
+const echo = (ctx: restate.RpcContext, msg: any): Promise<any> => {
   return msg;
 };
-const echoEcho = async (ctx: restate.RpcContext, msg: any) => {
+const echoEcho = async (ctx: restate.RpcContext, msg: any): Promise<any> => {
   return await ctx.rpc(handlerApi).echo(msg);
 };
 


### PR DESCRIPTION
The code before that PR doesn't compile  with the newest typescript SDK as it is missing either an explicit type annotation, or  an explicit type on the call site.

With the PR

```

Error: src/src/handler_api.ts(9,7): error TS7023: 'echoEcho' implicitly has return type 'any' because it does not have a return type annotation and is referenced directly or indirectly in one of its return expressions.
Error: src/src/handler_api.ts(10,16): error TS2615: Type of property 'echoEcho' circularly references itself in mapped type 'UnKeyedRouter<{ echo: (ctx: RpcContext, msg: any) => any; echoEcho: (ctx: RpcContext, msg: any) => any; }>'.

```

with it, everything builds successfully.
