### PR TITLE
Remove auth

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -91,13 +91,6 @@ jobs:
           node-version: "18.x"
           registry-url: 'https://registry.npmjs.org'
 
-      - name: Log in to the Container registry
-        uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
-        with:
-          registry: ghcr.io
-          username: ${{ secrets.GH_PACKAGE_READ_ACCESS_USER }}
-          password: ${{ secrets.GH_PACKAGE_READ_ACCESS_TOKEN }}
-
       # Setup sdk-typescript snapshot if necessary
       # Due to https://github.com/actions/upload-artifact/issues/53
       # We must use download-artifact to get artifacts created during *this* workflow run, ie by workflow call

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -126,7 +126,6 @@ jobs:
           # if we are in a workflow_call, use the e2e branch from the workflow call (usually main)
           # otherwise, defer to the checkout actions default, which depends on the triggering event
           ref: ${{ inputs.sdkJavaCommit }}
-          token: ${{ secrets.SDK_JAVA_CONTENTS_READ_TOKEN || secrets.GITHUB_TOKEN  }}
           path: "sdk-java"
 
       # Setup restate snapshot if necessary

--- a/README.md
+++ b/README.md
@@ -10,14 +10,6 @@ E2E tests for Restate
 * `tests` contains the test code
 * `contracts` contains the different protobuf definitions, used by services and tests
 
-## Setup local env
-
-To run locally, you need to login to the container registry using podman/docker (the command is the same for both):
-
-```shell
-docker login ghcr.io --username $GH_PACKAGE_READ_ACCESS_USER --password $GH_PACKAGE_READ_ACCESS_TOKEN
-```
-
 ## Run tests
 
 To run tests, just execute:


### PR DESCRIPTION
This commit removes authentication for accessing public images. Moreover,
it replaces ghcr.io/restatede/restate-dist with docker.io/restatedev/restate.