### PR TITLE
Cleanup the loading of env variables for the runtime container

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -160,7 +160,7 @@ jobs:
         env:
           E2E_IMAGE_PULL_POLICY: always
           E2E_VERIFICATION_SEED: ${{ github.run_id }}
-          RESTATE_RUNTIME_CONTAINER: ${{ inputs.restateCommit != '' && 'localhost:5000/restatedev/restate:latest' || '' }}
+          RESTATE_CONTAINER_IMAGE: ${{ inputs.restateCommit != '' && 'localhost:5000/restatedev/restate:latest' || '' }}
           JAVA_SDK_LOCAL_BUILD: ${{ inputs.sdkJavaCommit != '' && 'true' || '' }}
         with:
           arguments: -Djib.console=plain check

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ You can include `gradle :services:node-services:installLocalSdkTypescript` in th
 
 ### How to test Restate runtime changes
 
-You can manually build a docker image in the restate project using `just docker`. Then set the environment variable `RESTATE_RUNTIME_CONTAINER` with the tag of the newly created image (printed at the end of the docker build log).
+You can manually build a docker image in the restate project using `just docker`. Then set the environment variable `RESTATE_CONTAINER_IMAGE` with the tag of the newly created image (printed at the end of the docker build log).
 
 ### Retain runtime state after test
 

--- a/test-utils/src/main/kotlin/dev/restate/e2e/utils/RestateDeployer.kt
+++ b/test-utils/src/main/kotlin/dev/restate/e2e/utils/RestateDeployer.kt
@@ -43,7 +43,7 @@ private constructor(
     runtimeDeployments: Int,
     serviceSpecs: List<ServiceSpec>,
     private val additionalContainers: Map<String, GenericContainer<*>>,
-    private val additionalEnv: Map<String, String>,
+    private val runtimeContainerEnvs: Map<String, String>,
     private val runtimeContainerName: String,
     private val enableTracesExport: Boolean,
     private val configSchema: RestateConfigSchema?
@@ -145,12 +145,13 @@ private constructor(
       private var runtimeDeployments: Int = 1,
       private var serviceEndpoints: MutableList<ServiceSpec> = mutableListOf(),
       private var additionalContainers: MutableMap<String, GenericContainer<*>> = mutableMapOf(),
-      private var additionalEnv: MutableMap<String, String> = mutableMapOf(),
-      private var runtimeContainer: String =
+      private var runtimeContainerEnvs: MutableMap<String, String> = mutableMapOf(),
+      private var runtimeContainerImage: String =
           System.getenv(RESTATE_RUNTIME_CONTAINER_ENV) ?: DEFAULT_RUNTIME_CONTAINER,
       private var invokerRetryPolicy: RetryPolicy? = null,
       private var enableTracesExport: Boolean = true,
-      private var configSchema: RestateConfigSchema? = null
+      private var configSchema: RestateConfigSchema? = null,
+      private var loadEnvs: Boolean = true
   ) {
 
     fun withServiceEndpoint(serviceSpec: ServiceSpec) = apply {
@@ -170,8 +171,8 @@ private constructor(
       this.runtimeDeployments = runtimeDeployments
     }
 
-    fun runtimeContainer(runtimeContainer: String) = apply {
-      this.runtimeContainer = runtimeContainer
+    fun restateContainerImage(runtimeContainer: String) = apply {
+      this.runtimeContainerImage = runtimeContainer
     }
 
     /** Add a container that will be added within the same network of functions and runtime. */
@@ -183,9 +184,9 @@ private constructor(
       this.additionalContainers[entry.first] = entry.second
     }
 
-    fun withEnv(key: String, value: String) = apply { this.additionalEnv[key] = value }
+    fun withEnv(key: String, value: String) = apply { this.runtimeContainerEnvs[key] = value }
 
-    fun withEnv(map: Map<String, String>) = apply { this.additionalEnv.putAll(map) }
+    fun withEnv(map: Map<String, String>) = apply { this.runtimeContainerEnvs.putAll(map) }
 
     fun withInvokerRetryPolicy(policy: RetryPolicy) = apply { this.invokerRetryPolicy = policy }
 
@@ -193,15 +194,31 @@ private constructor(
 
     fun withConfig(configSchema: RestateConfigSchema) = apply { this.configSchema = configSchema }
 
-    fun build() =
-        RestateDeployer(
-            runtimeDeployments,
-            serviceEndpoints,
-            additionalContainers,
-            additionalEnv + (invokerRetryPolicy?.toInvokerSetupEnv() ?: emptyMap()),
-            runtimeContainer,
-            enableTracesExport,
-            configSchema)
+    fun disableLoadingRestateEnv() = apply { this.loadEnvs = false }
+
+    fun build(): RestateDeployer {
+      val loadedRuntimeContainerEnvs =
+          if (this.loadEnvs) {
+            System.getenv().filterKeys {
+              (it.uppercase().startsWith("RESTATE_") &&
+                  it.uppercase() != "RESTATE_RUNTIME_CONTAINER") ||
+                  it.uppercase().startsWith("RUST_")
+            }
+          } else {
+            emptyMap()
+          }
+
+      return RestateDeployer(
+          runtimeDeployments,
+          serviceEndpoints,
+          additionalContainers,
+          loadedRuntimeContainerEnvs +
+              this.runtimeContainerEnvs +
+              (invokerRetryPolicy?.toInvokerSetupEnv() ?: emptyMap()),
+          runtimeContainerImage,
+          enableTracesExport,
+          configSchema)
+    }
   }
 
   fun deployAll(testReportDir: String) {
@@ -289,7 +306,7 @@ private constructor(
         .withExposedPorts(RUNTIME_GRPC_INGRESS_ENDPOINT_PORT, RUNTIME_META_ENDPOINT_PORT)
         .dependsOn(serviceContainers.values.map { it.second })
         .dependsOn(additionalContainers.values)
-        .withEnv(additionalEnv)
+        .withEnv(runtimeContainerEnvs)
         // These envs should not be overriden by additionalEnv
         .withEnv("RESTATE_META__REST_ADDRESS", "0.0.0.0:${RUNTIME_META_ENDPOINT_PORT}")
         .withEnv(

--- a/tests/build.gradle.kts
+++ b/tests/build.gradle.kts
@@ -55,10 +55,10 @@ tasks {
                   .absolutePath,
           // We don't need many partitions, fewer partitions will occupy less test resources
           "RESTATE_WORKER__PARTITIONS" to "10",
-          "RESTATE_RUNTIME_CONTAINER" to
-              (if (System.getenv("RESTATE_RUNTIME_CONTAINER").isNullOrEmpty())
+          "RESTATE_CONTAINER_IMAGE" to
+              (if (System.getenv("RESTATE_CONTAINER_IMAGE").isNullOrEmpty())
                   "ghcr.io/restatedev/restate:main"
-              else System.getenv("RESTATE_RUNTIME_CONTAINER")),
+              else System.getenv("RESTATE_CONTAINER_IMAGE")),
           "RUST_LOG" to (System.getenv("RUST_LOG") ?: defaultLog),
           "RUST_BACKTRACE" to "full")
 

--- a/tests/src/test/kotlin/dev/restate/e2e/AwakeableTest.kt
+++ b/tests/src/test/kotlin/dev/restate/e2e/AwakeableTest.kt
@@ -26,7 +26,6 @@ class JavaAwakeableTest : BaseAwakeableTest() {
     val deployerExt: RestateDeployerExtension =
         RestateDeployerExtension(
             RestateDeployer.Builder()
-                .withEnv(Containers.getRestateEnvironment())
                 .withServiceEndpoint(Containers.JAVA_EXTERNALCALL_SERVICE_SPEC)
                 .withContainer(Containers.INT_SORTER_HTTP_SERVER_CONTAINER_SPEC)
                 .build())
@@ -40,7 +39,6 @@ class NodeAwakeableTest : BaseAwakeableTest() {
     val deployerExt: RestateDeployerExtension =
         RestateDeployerExtension(
             RestateDeployer.Builder()
-                .withEnv(Containers.getRestateEnvironment())
                 .withServiceEndpoint(Containers.NODE_EXTERNALCALL_SERVICE_SPEC)
                 .withContainer(Containers.INT_SORTER_HTTP_SERVER_CONTAINER_SPEC)
                 .build())
@@ -53,7 +51,6 @@ class NodeWithBase64CompletionAwakeableTest : BaseAwakeableTest() {
     val deployerExt: RestateDeployerExtension =
         RestateDeployerExtension(
             RestateDeployer.Builder()
-                .withEnv(Containers.getRestateEnvironment())
                 .withServiceEndpoint(Containers.NODE_EXTERNALCALL_SERVICE_SPEC)
                 .withContainer(
                     Containers.INT_SORTER_HTTP_SERVER_HOSTNAME to

--- a/tests/src/test/kotlin/dev/restate/e2e/Containers.kt
+++ b/tests/src/test/kotlin/dev/restate/e2e/Containers.kt
@@ -35,13 +35,6 @@ object Containers {
   val INT_SORTER_HTTP_SERVER_CONTAINER_SPEC =
       INT_SORTER_HTTP_SERVER_HOSTNAME to intSorterHttpServerContainer()
 
-  fun getRestateEnvironment(): Map<String, String> {
-    return System.getenv().filterKeys {
-      (it.uppercase().startsWith("RESTATE_") && it.uppercase() != "RESTATE_RUNTIME_CONTAINER") ||
-          it.uppercase().startsWith("RUST_")
-    }
-  }
-
   // -- Java containers
 
   fun javaServicesContainer(hostName: String, vararg services: String): ServiceSpec.Builder {

--- a/tests/src/test/kotlin/dev/restate/e2e/ErrorsTest.kt
+++ b/tests/src/test/kotlin/dev/restate/e2e/ErrorsTest.kt
@@ -39,7 +39,6 @@ class JavaErrorsTest : BaseErrorsTest() {
     val deployerExt: RestateDeployerExtension =
         RestateDeployerExtension(
             RestateDeployer.Builder()
-                .withEnv(Containers.getRestateEnvironment())
                 .withServiceEndpoint(Containers.JAVA_ERRORS_SERVICE_SPEC)
                 .withServiceEndpoint(Containers.JAVA_EXTERNALCALL_SERVICE_SPEC)
                 .withServiceEndpoint(Containers.JAVA_COUNTER_SERVICE_SPEC)
@@ -67,7 +66,6 @@ class NodeErrorsTest : BaseErrorsTest() {
     val deployerExt: RestateDeployerExtension =
         RestateDeployerExtension(
             RestateDeployer.Builder()
-                .withEnv(Containers.getRestateEnvironment())
                 .withServiceEndpoint(Containers.NODE_ERRORS_SERVICE_SPEC)
                 .withServiceEndpoint(Containers.NODE_COUNTER_SERVICE_SPEC)
                 .build())

--- a/tests/src/test/kotlin/dev/restate/e2e/KafkaIngressTest.kt
+++ b/tests/src/test/kotlin/dev/restate/e2e/KafkaIngressTest.kt
@@ -61,7 +61,6 @@ class JavaKafkaIngressTest : BaseKafkaIngressTest() {
     val deployerExt: RestateDeployerExtension =
         RestateDeployerExtension(
             RestateDeployer.Builder()
-                .withEnv(Containers.getRestateEnvironment())
                 .withServiceEndpoint(
                     Containers.javaServicesContainer(
                         "java-counter", CounterGrpc.SERVICE_NAME, EventHandlerGrpc.SERVICE_NAME))
@@ -77,7 +76,6 @@ class NodeKafkaIngressTest : BaseKafkaIngressTest() {
     val deployerExt: RestateDeployerExtension =
         RestateDeployerExtension(
             RestateDeployer.Builder()
-                .withEnv(Containers.getRestateEnvironment())
                 .withServiceEndpoint(
                     Containers.nodeServicesContainer(
                         "node-counter", CounterGrpc.SERVICE_NAME, EventHandlerGrpc.SERVICE_NAME))
@@ -153,7 +151,6 @@ class NodeHandlerAPIKafkaIngressTest {
     val deployerExt: RestateDeployerExtension =
         RestateDeployerExtension(
             RestateDeployer.Builder()
-                .withEnv(Containers.getRestateEnvironment())
                 .withServiceEndpoint(
                     Containers.nodeServicesContainer(
                         "node-counter", Containers.HANDLER_API_COUNTER_SERVICE_NAME))

--- a/tests/src/test/kotlin/dev/restate/e2e/NonDeterminismTest.kt
+++ b/tests/src/test/kotlin/dev/restate/e2e/NonDeterminismTest.kt
@@ -39,7 +39,6 @@ class JavaNonDeterminismTest : NonDeterminismTest() {
     val deployerExt: RestateDeployerExtension =
         RestateDeployerExtension(
             RestateDeployer.Builder()
-                .withEnv(Containers.getRestateEnvironment())
                 .withInvokerRetryPolicy(RestateDeployer.RetryPolicy.None)
                 .withServiceEndpoint(
                     Containers.javaServicesContainer(
@@ -57,7 +56,6 @@ class NodeNonDeterminismTest : NonDeterminismTest() {
     val deployerExt: RestateDeployerExtension =
         RestateDeployerExtension(
             RestateDeployer.Builder()
-                .withEnv(Containers.getRestateEnvironment())
                 // Disable the retries so we get the error propagated back
                 .withInvokerRetryPolicy(RestateDeployer.RetryPolicy.None)
                 .withServiceEndpoint(

--- a/tests/src/test/kotlin/dev/restate/e2e/SampleWorkflowTest.kt
+++ b/tests/src/test/kotlin/dev/restate/e2e/SampleWorkflowTest.kt
@@ -31,7 +31,6 @@ class JavaSampleWorkflowTest : BaseSampleWorkflowTest() {
     val deployerExt: RestateDeployerExtension =
         RestateDeployerExtension(
             RestateDeployer.Builder()
-                .withEnv(Containers.getRestateEnvironment())
                 .withServiceEndpoint(Containers.JAVA_COORDINATOR_SERVICE_SPEC)
                 .build())
   }
@@ -44,7 +43,6 @@ class NodeSampleWorkflowTest : BaseSampleWorkflowTest() {
     val deployerExt: RestateDeployerExtension =
         RestateDeployerExtension(
             RestateDeployer.Builder()
-                .withEnv(Containers.getRestateEnvironment())
                 .withServiceEndpoint(Containers.NODE_COORDINATOR_SERVICE_SPEC)
                 .build())
   }

--- a/tests/src/test/kotlin/dev/restate/e2e/ServiceToServiceCallTest.kt
+++ b/tests/src/test/kotlin/dev/restate/e2e/ServiceToServiceCallTest.kt
@@ -31,7 +31,6 @@ class JavaServiceToServiceCallTest : BaseServiceToServiceCallTest() {
     val deployerExt: RestateDeployerExtension =
         RestateDeployerExtension(
             RestateDeployer.Builder()
-                .withEnv(Containers.getRestateEnvironment())
                 .withServiceEndpoint(Containers.JAVA_COORDINATOR_SERVICE_SPEC)
                 .build())
   }
@@ -44,7 +43,6 @@ class NodeServiceToServiceCallTest : BaseServiceToServiceCallTest() {
     val deployerExt: RestateDeployerExtension =
         RestateDeployerExtension(
             RestateDeployer.Builder()
-                .withEnv(Containers.getRestateEnvironment())
                 .withServiceEndpoint(Containers.NODE_COORDINATOR_SERVICE_SPEC)
                 .build())
   }
@@ -57,7 +55,6 @@ class JavaCoordinatorWithNodeReceiverServiceToServiceCallTest : BaseServiceToSer
     val deployerExt: RestateDeployerExtension =
         RestateDeployerExtension(
             RestateDeployer.Builder()
-                .withEnv(Containers.getRestateEnvironment())
                 .withServiceEndpoint(
                     javaServicesContainer("java-coordinator", CoordinatorGrpc.SERVICE_NAME))
                 .withServiceEndpoint(
@@ -73,7 +70,6 @@ class NodeCoordinatorWithJavaReceiverServiceToServiceCallTest : BaseServiceToSer
     val deployerExt: RestateDeployerExtension =
         RestateDeployerExtension(
             RestateDeployer.Builder()
-                .withEnv(Containers.getRestateEnvironment())
                 .withServiceEndpoint(
                     nodeServicesContainer("node-coordinator", CoordinatorGrpc.SERVICE_NAME))
                 .withServiceEndpoint(

--- a/tests/src/test/kotlin/dev/restate/e2e/SideEffectTest.kt
+++ b/tests/src/test/kotlin/dev/restate/e2e/SideEffectTest.kt
@@ -33,7 +33,6 @@ class JavaSideEffectTest : BaseSideEffectTest() {
     val deployerExt: RestateDeployerExtension =
         RestateDeployerExtension(
             RestateDeployer.Builder()
-                .withEnv(Containers.getRestateEnvironment())
                 .withServiceEndpoint(
                     Containers.javaServicesContainer(
                         "java-side-effect", SideEffectGrpc.SERVICE_NAME))
@@ -52,7 +51,6 @@ class NodeSideEffectTest : BaseSideEffectTest() {
     val deployerExt: RestateDeployerExtension =
         RestateDeployerExtension(
             RestateDeployer.Builder()
-                .withEnv(Containers.getRestateEnvironment())
                 .withServiceEndpoint(
                     Containers.nodeServicesContainer(
                         "node-side-effect", SideEffectGrpc.SERVICE_NAME))

--- a/tests/src/test/kotlin/dev/restate/e2e/SleepTest.kt
+++ b/tests/src/test/kotlin/dev/restate/e2e/SleepTest.kt
@@ -43,7 +43,6 @@ class JavaSimpleSleepTest : BaseSimpleSleepTest() {
     val deployerExt: RestateDeployerExtension =
         RestateDeployerExtension(
             RestateDeployer.Builder()
-                .withEnv(Containers.getRestateEnvironment())
                 .withServiceEndpoint(Containers.JAVA_COORDINATOR_SERVICE_SPEC)
                 .build())
   }
@@ -57,7 +56,6 @@ class NodeSimpleSleepTest : BaseSimpleSleepTest() {
     val deployerExt: RestateDeployerExtension =
         RestateDeployerExtension(
             RestateDeployer.Builder()
-                .withEnv(Containers.getRestateEnvironment())
                 .withServiceEndpoint(Containers.NODE_COORDINATOR_SERVICE_SPEC)
                 .build())
   }
@@ -123,7 +121,6 @@ class JavaSleepWithFailuresTest : BaseSleepWithFailuresTest() {
     @RegisterExtension
     val deployerExt: RestateDeployerForEachExtension = RestateDeployerForEachExtension {
       RestateDeployer.Builder()
-          .withEnv(Containers.getRestateEnvironment())
           .withServiceEndpoint(
               Containers.JAVA_COORDINATOR_SERVICE_SPEC.copy(hostName = COORDINATOR_HOSTNAME))
           .build()
@@ -137,7 +134,6 @@ class NodeSleepWithFailuresTest : BaseSleepWithFailuresTest() {
     @RegisterExtension
     val deployerExt: RestateDeployerForEachExtension = RestateDeployerForEachExtension {
       RestateDeployer.Builder()
-          .withEnv(Containers.getRestateEnvironment())
           .withServiceEndpoint(
               Containers.NODE_COORDINATOR_SERVICE_SPEC.copy(
                   hostName = COORDINATOR_HOSTNAME,

--- a/tests/src/test/kotlin/dev/restate/e2e/StateTest.kt
+++ b/tests/src/test/kotlin/dev/restate/e2e/StateTest.kt
@@ -35,7 +35,6 @@ class JavaStateTest : BaseStateTest() {
     val deployerExt: RestateDeployerExtension =
         RestateDeployerExtension(
             RestateDeployer.Builder()
-                .withEnv(Containers.getRestateEnvironment())
                 .withServiceEndpoint(Containers.JAVA_COUNTER_SERVICE_SPEC)
                 .build())
   }
@@ -50,7 +49,6 @@ class NodeStateTest : BaseStateTest() {
     val deployerExt: RestateDeployerExtension =
         RestateDeployerExtension(
             RestateDeployer.Builder()
-                .withEnv(Containers.getRestateEnvironment())
                 .withServiceEndpoint(Containers.NODE_COUNTER_SERVICE_SPEC)
                 .build())
   }

--- a/tests/src/test/kotlin/dev/restate/e2e/java/AwaitTimeoutTest.kt
+++ b/tests/src/test/kotlin/dev/restate/e2e/java/AwaitTimeoutTest.kt
@@ -33,7 +33,6 @@ class AwaitTimeoutTest {
     val deployerExt: RestateDeployerExtension =
         RestateDeployerExtension(
             RestateDeployer.Builder()
-                .withEnv(Containers.getRestateEnvironment())
                 .withServiceEndpoint(Containers.JAVA_COORDINATOR_SERVICE_SPEC)
                 .build())
   }

--- a/tests/src/test/kotlin/dev/restate/e2e/node/EmbeddedHandlerApiTest.kt
+++ b/tests/src/test/kotlin/dev/restate/e2e/node/EmbeddedHandlerApiTest.kt
@@ -35,7 +35,6 @@ class EmbeddedHandlerApiTest {
     val deployerExt: RestateDeployerExtension =
         RestateDeployerExtension(
             RestateDeployer.Builder()
-                .withEnv(Containers.getRestateEnvironment())
                 .withContainer(EMBEDDED_HANDLER_SERVER_CONTAINER_SPEC)
                 .withContainer(Containers.INT_SORTER_HTTP_SERVER_CONTAINER_SPEC)
                 .withServiceEndpoint(

--- a/tests/src/test/kotlin/dev/restate/e2e/node/HandlerApiTest.kt
+++ b/tests/src/test/kotlin/dev/restate/e2e/node/HandlerApiTest.kt
@@ -35,7 +35,6 @@ class HandlerApiTest {
     val deployerExt: RestateDeployerExtension =
         RestateDeployerExtension(
             RestateDeployer.Builder()
-                .withEnv(Containers.getRestateEnvironment())
                 .withServiceEndpoint(Containers.NODE_HANDLER_API_ECHO_TEST_SERVICE_SPEC)
                 .build())
 

--- a/tests/src/test/kotlin/dev/restate/e2e/node/StateSerDeTest.kt
+++ b/tests/src/test/kotlin/dev/restate/e2e/node/StateSerDeTest.kt
@@ -30,7 +30,6 @@ class StateSerDeTest {
     val deployerExt: RestateDeployerExtension =
         RestateDeployerExtension(
             RestateDeployer.Builder()
-                .withEnv(Containers.getRestateEnvironment())
                 .withServiceEndpoint(Containers.NODE_COLLECTIONS_SERVICE_SPEC)
                 .build())
   }

--- a/tests/src/test/kotlin/dev/restate/e2e/node/VerificationTest.kt
+++ b/tests/src/test/kotlin/dev/restate/e2e/node/VerificationTest.kt
@@ -44,10 +44,7 @@ class VerificationTest {
     @JvmStatic
     @RegisterExtension
     val deployerExt: RestateDeployerForEachExtension = RestateDeployerForEachExtension {
-      RestateDeployer.Builder()
-          .withEnv(Containers.getRestateEnvironment())
-          .withServiceEndpoint(Containers.VERIFICATION_SERVICE_SPEC)
-          .build()
+      RestateDeployer.Builder().withServiceEndpoint(Containers.VERIFICATION_SERVICE_SPEC).build()
     }
 
     private const val E2E_VERIFICATION_SEED_ENV = "E2E_VERIFICATION_SEED"

--- a/tests/src/test/kotlin/dev/restate/e2e/runtime/ConnectIngressTest.kt
+++ b/tests/src/test/kotlin/dev/restate/e2e/runtime/ConnectIngressTest.kt
@@ -36,7 +36,6 @@ class ConnectIngressTest {
     val deployerExt: RestateDeployerExtension =
         RestateDeployerExtension(
             RestateDeployer.Builder()
-                .withEnv(Containers.getRestateEnvironment())
                 .withServiceEndpoint(Containers.JAVA_COUNTER_SERVICE_SPEC)
                 .build())
 

--- a/tests/src/test/kotlin/dev/restate/e2e/runtime/IngressServiceTest.kt
+++ b/tests/src/test/kotlin/dev/restate/e2e/runtime/IngressServiceTest.kt
@@ -50,7 +50,6 @@ class IngressServiceTest {
     val deployerExt: RestateDeployerExtension =
         RestateDeployerExtension(
             RestateDeployer.Builder()
-                .withEnv(Containers.getRestateEnvironment())
                 .withServiceEndpoint(Containers.JAVA_COUNTER_SERVICE_SPEC)
                 .build())
   }

--- a/tests/src/test/kotlin/dev/restate/e2e/runtime/InvokeOrderingTest.kt
+++ b/tests/src/test/kotlin/dev/restate/e2e/runtime/InvokeOrderingTest.kt
@@ -34,7 +34,6 @@ class InvokeOrderingTest {
     val deployerExt: RestateDeployerExtension =
         RestateDeployerExtension(
             RestateDeployer.Builder()
-                .withEnv(Containers.getRestateEnvironment())
                 .withServiceEndpoint(Containers.JAVA_COORDINATOR_SERVICE_SPEC)
                 .withServiceEndpoint(Containers.JAVA_COLLECTIONS_SERVICE_SPEC)
                 .build())

--- a/tests/src/test/kotlin/dev/restate/e2e/runtime/KillInvocationTest.kt
+++ b/tests/src/test/kotlin/dev/restate/e2e/runtime/KillInvocationTest.kt
@@ -38,7 +38,6 @@ class KillInvocationTest {
     @RegisterExtension
     val deployerExt: RestateDeployerForEachExtension = RestateDeployerForEachExtension {
       RestateDeployer.Builder()
-          .withEnv(Containers.getRestateEnvironment())
           .withServiceEndpoint(
               Containers.nodeServicesContainer(
                   "services", CounterGrpc.SERVICE_NAME, AwakeableHolderServiceGrpc.SERVICE_NAME))

--- a/tests/src/test/kotlin/dev/restate/e2e/runtime/PersistenceTest.kt
+++ b/tests/src/test/kotlin/dev/restate/e2e/runtime/PersistenceTest.kt
@@ -24,10 +24,7 @@ class PersistenceTest {
     @JvmStatic
     @RegisterExtension
     val deployerExt: RestateDeployerForEachExtension = RestateDeployerForEachExtension {
-      RestateDeployer.Builder()
-          .withEnv(Containers.getRestateEnvironment())
-          .withServiceEndpoint(Containers.NODE_COUNTER_SERVICE_SPEC)
-          .build()
+      RestateDeployer.Builder().withServiceEndpoint(Containers.NODE_COUNTER_SERVICE_SPEC).build()
     }
   }
 

--- a/tests/src/test/kotlin/dev/restate/e2e/runtime/PrivateServiceTest.kt
+++ b/tests/src/test/kotlin/dev/restate/e2e/runtime/PrivateServiceTest.kt
@@ -40,7 +40,6 @@ class PrivateServiceTest {
     val deployerExt: RestateDeployerExtension =
         RestateDeployerExtension(
             RestateDeployer.Builder()
-                .withEnv(Containers.getRestateEnvironment())
                 .withServiceEndpoint(Containers.NODE_COUNTER_SERVICE_SPEC)
                 .build())
   }

--- a/tests/src/test/kotlin/dev/restate/e2e/runtime/RetryOnUnknownServiceTest.kt
+++ b/tests/src/test/kotlin/dev/restate/e2e/runtime/RetryOnUnknownServiceTest.kt
@@ -42,7 +42,6 @@ class RetryOnUnknownServiceTest {
     @RegisterExtension
     val deployerExt: RestateDeployerForEachExtension = RestateDeployerForEachExtension {
       RestateDeployer.Builder()
-          .withEnv(Containers.getRestateEnvironment())
           .withServiceEndpoint(Containers.NODE_PROXY_SERVICE_SPEC)
           .withServiceEndpoint(
               Containers.NODE_COLLECTIONS_SERVICE_SPEC.copy(skipRegistration = true))

--- a/tests/src/test/kotlin/dev/restate/e2e/runtime/SingletonCounterTest.kt
+++ b/tests/src/test/kotlin/dev/restate/e2e/runtime/SingletonCounterTest.kt
@@ -29,7 +29,6 @@ class SingletonCounterTest {
     val deployerExt: RestateDeployerExtension =
         RestateDeployerExtension(
             RestateDeployer.Builder()
-                .withEnv(Containers.getRestateEnvironment())
                 .withServiceEndpoint(Containers.JAVA_COUNTER_SERVICE_SPEC)
                 .build())
   }

--- a/tests/src/test/kotlin/dev/restate/e2e/runtime/UpgradeServiceTest.kt
+++ b/tests/src/test/kotlin/dev/restate/e2e/runtime/UpgradeServiceTest.kt
@@ -42,7 +42,6 @@ class UpgradeServiceTest {
     @RegisterExtension
     val deployerExt: RestateDeployerForEachExtension = RestateDeployerForEachExtension {
       RestateDeployer.Builder()
-          .withEnv(Containers.getRestateEnvironment())
           .withServiceEndpoint(
               Containers.javaServicesContainer(
                       "version1", UpgradeTestServiceGrpc.SERVICE_NAME, ListServiceGrpc.SERVICE_NAME)


### PR DESCRIPTION
In past we kept this in the utils module because we wanted to release the test-utils, which is not the case anymore now.