### PR TITLE
Add tests for cancellation

### DIFF
--- a/contracts/src/main/proto/cancel_test.proto
+++ b/contracts/src/main/proto/cancel_test.proto
@@ -1,0 +1,46 @@
+// Copyright (c) 2023 - Restate Software, Inc., Restate GmbH
+//
+// This file is part of the Restate e2e tests,
+// which are released under the MIT license.
+//
+// You can find a copy of the license in file LICENSE in the root
+// directory of this repository or package, or at
+// https://github.com/restatedev/e2e/blob/main/LICENSE
+
+syntax = "proto3";
+
+option java_package = "dev.restate.e2e.services.canceltest";
+option java_outer_classname = "CancelTestProto";
+
+import "google/protobuf/empty.proto";
+import "dev/restate/ext.proto";
+
+package cancel_test;
+
+service CancelTestService {
+  option (dev.restate.ext.service_type) = SINGLETON;
+
+  rpc StartTest(BlockingRequest) returns (google.protobuf.Empty);
+  rpc VerifyTest(google.protobuf.Empty) returns (Response);
+}
+
+enum BlockingOperation {
+  CALL = 0;
+  SLEEP = 1;
+  AWAKEABLE = 2;
+}
+
+message BlockingRequest {
+  BlockingOperation operation = 1;
+}
+
+message Response {
+  bool is_canceled = 1;
+}
+
+service BlockingService {
+  option (dev.restate.ext.service_type) = SINGLETON;
+
+  rpc Block(BlockingRequest) returns (google.protobuf.Empty);
+  rpc IsUnlocked(google.protobuf.Empty) returns (google.protobuf.Empty);
+}

--- a/services/java-services/src/main/java/dev/restate/e2e/services/Main.java
+++ b/services/java-services/src/main/java/dev/restate/e2e/services/Main.java
@@ -81,6 +81,14 @@ public class Main {
         case EventHandlerGrpc.SERVICE_NAME:
           restateHttpEndpointBuilder.withService(new EventHandlerService());
           break;
+        case dev.restate.e2e.services.canceltest.CancelTestServiceGrpc.SERVICE_NAME:
+          restateHttpEndpointBuilder.withService(
+              new dev.restate.e2e.services.canceltest.CancelTestService());
+          break;
+        case dev.restate.e2e.services.canceltest.BlockingServiceGrpc.SERVICE_NAME:
+          restateHttpEndpointBuilder.withService(
+              new dev.restate.e2e.services.canceltest.BlockingService());
+          break;
       }
     }
 

--- a/services/java-services/src/main/java/dev/restate/e2e/services/canceltest/BlockingService.java
+++ b/services/java-services/src/main/java/dev/restate/e2e/services/canceltest/BlockingService.java
@@ -1,0 +1,59 @@
+// Copyright (c) 2023 - Restate Software, Inc., Restate GmbH
+//
+// This file is part of the Restate e2e tests,
+// which are released under the MIT license.
+//
+// You can find a copy of the license in file LICENSE in the root
+// directory of this repository or package, or at
+// https://github.com/restatedev/e2e/blob/main/LICENSE
+
+package dev.restate.e2e.services.canceltest;
+
+import dev.restate.e2e.services.awakeableholder.AwakeableHolderProto;
+import dev.restate.e2e.services.awakeableholder.AwakeableHolderServiceRestate;
+import dev.restate.sdk.Awakeable;
+import dev.restate.sdk.RestateContext;
+import dev.restate.sdk.common.CoreSerdes;
+import dev.restate.sdk.common.TerminalException;
+import java.time.Duration;
+
+public class BlockingService extends BlockingServiceRestate.BlockingServiceRestateImplBase {
+  @Override
+  public void block(RestateContext context, CancelTestProto.BlockingRequest request)
+      throws TerminalException {
+    final BlockingServiceRestate.BlockingServiceRestateClient self =
+        BlockingServiceRestate.newClient(context);
+    final AwakeableHolderServiceRestate.AwakeableHolderServiceRestateClient client =
+        AwakeableHolderServiceRestate.newClient(context);
+
+    Awakeable<String> awakeable = context.awakeable(CoreSerdes.STRING_UTF8);
+    client
+        .hold(
+            AwakeableHolderProto.HoldRequest.newBuilder()
+                .setName("cancel")
+                .setId(awakeable.id())
+                .build())
+        .await();
+    awakeable.await();
+
+    switch (request.getOperation()) {
+      case CALL:
+        self.block(request).await();
+        break;
+      case SLEEP:
+        context.sleep(Duration.ofDays(1024));
+        break;
+      case AWAKEABLE:
+        Awakeable<String> uncompletable = context.awakeable(CoreSerdes.STRING_UTF8);
+        uncompletable.await();
+        break;
+      default:
+        throw new IllegalArgumentException("Unknown operation: " + request.getOperation());
+    }
+  }
+
+  @Override
+  public void isUnlocked(RestateContext context) throws TerminalException {
+    // no-op
+  }
+}

--- a/services/java-services/src/main/java/dev/restate/e2e/services/canceltest/CancelTestService.java
+++ b/services/java-services/src/main/java/dev/restate/e2e/services/canceltest/CancelTestService.java
@@ -1,0 +1,43 @@
+// Copyright (c) 2023 - Restate Software, Inc., Restate GmbH
+//
+// This file is part of the Restate e2e tests,
+// which are released under the MIT license.
+//
+// You can find a copy of the license in file LICENSE in the root
+// directory of this repository or package, or at
+// https://github.com/restatedev/e2e/blob/main/LICENSE
+
+package dev.restate.e2e.services.canceltest;
+
+import dev.restate.sdk.RestateContext;
+import dev.restate.sdk.common.CoreSerdes;
+import dev.restate.sdk.common.StateKey;
+import dev.restate.sdk.common.TerminalException;
+
+public class CancelTestService extends CancelTestServiceRestate.CancelTestServiceRestateImplBase {
+  private static StateKey<Boolean> CANCELED_STATE = StateKey.of("canceled", CoreSerdes.BOOLEAN);
+
+  @Override
+  public void startTest(RestateContext ctx, CancelTestProto.BlockingRequest request)
+      throws TerminalException {
+    BlockingServiceRestate.BlockingServiceRestateClient client =
+        BlockingServiceRestate.newClient(ctx);
+
+    try {
+      client.block(request).await();
+    } catch (TerminalException e) {
+      if (e.getCode() == TerminalException.Code.CANCELLED) {
+        ctx.set(CANCELED_STATE, true);
+      } else {
+        throw e;
+      }
+    }
+  }
+
+  @Override
+  public CancelTestProto.Response verifyTest(RestateContext context) throws TerminalException {
+    return CancelTestProto.Response.newBuilder()
+        .setIsCanceled(context.get(CANCELED_STATE).orElse(false))
+        .build();
+  }
+}

--- a/services/node-services/src/app.ts
+++ b/services/node-services/src/app.ts
@@ -23,6 +23,7 @@ import { protoMetadata as rngProtoMetadata } from "./generated/rng";
 import { protoMetadata as awakeableHolderProtoMetadata } from "./generated/awakeable_holder";
 import { protoMetadata as eventHandlerProtoMetadata } from "./generated/event_handler";
 import { protoMetadata as killTestProtoMetadata } from "./generated/kill_test";
+import { protoMetadata as cancelTestProtoMetadata } from "./generated/cancel_test";
 import { CounterService, CounterServiceFQN } from "./counter";
 import { ListService, ListServiceFQN } from "./collections";
 import { FailingService, FailingServiceFQN } from "./errors";
@@ -57,6 +58,7 @@ import {
 import { EventHandlerFQN, EventHandlerService } from "./event_handler";
 import { startEmbeddedHandlerServer } from "./embedded_handler_api";
 import { KillSingletonServiceFQN, KillTestService, KillTestServiceFQN, KillSingletonService } from "./kill_test";
+import { BlockingServiceFQN, CancelTestService, CancelTestServiceFQN, BlockingService } from "./cancel_test";
 
 let serverBuilder;
 export let handler: (event: any) => Promise<any>;
@@ -209,7 +211,23 @@ const services = new Map<
       service: "KillSingletonService",
       instance: new KillSingletonService(),
     }
-  ]
+  ],
+  [
+    CancelTestServiceFQN,
+    {
+      descriptor: cancelTestProtoMetadata,
+      service: "CancelTestService",
+      instance: new CancelTestService(),
+    }
+  ],
+  [
+    BlockingServiceFQN,
+    {
+      descriptor: cancelTestProtoMetadata,
+      service: "BlockingService",
+      instance: new BlockingService(),
+    }
+  ],
 ]);
 console.log("Known services: " + services.keys());
 

--- a/services/node-services/src/awakeable_holder.ts
+++ b/services/node-services/src/awakeable_holder.ts
@@ -41,7 +41,7 @@ export class AwakeableHolderService implements IAwakeableHolderService {
     const ctx = restate.useContext(this);
 
     return {
-      hasAwakeable: (await ctx.get<string>(ID_KEY)) !== undefined,
+      hasAwakeable: (await ctx.get<string>(ID_KEY)) !== null,
     };
   }
 

--- a/services/node-services/src/cancel_test.ts
+++ b/services/node-services/src/cancel_test.ts
@@ -1,0 +1,86 @@
+// Copyright (c) 2023 - Restate Software, Inc., Restate GmbH
+//
+// This file is part of the Restate e2e tests,
+// which are released under the MIT license.
+//
+// You can find a copy of the license in file LICENSE in the root
+// directory of this repository or package, or at
+// https://github.com/restatedev/e2e/blob/main/LICENSE
+
+import * as restate from "@restatedev/restate-sdk";
+
+import {
+    CancelTestService as ICancelTestService,
+    BlockingService as IBlockingService,
+    protobufPackage,
+    BlockingServiceClientImpl,
+    Response,
+    BlockingOperation,
+    BlockingRequest,
+} from "./generated/cancel_test";
+import { Empty } from "./generated/google/protobuf/empty";
+import { AwakeableHolderServiceClientImpl } from "./generated/awakeable_holder";
+
+export const CancelTestServiceFQN = protobufPackage + ".CancelTestService";
+export const BlockingServiceFQN = protobufPackage + ".BlockingService";
+
+export class CancelTestService implements ICancelTestService {
+    async verifyTest(request: Empty): Promise<Response> {
+        const ctx = restate.useContext(this);
+        const isCanceled = await ctx.get<boolean>("canceled") ?? false;
+
+        return { isCanceled: isCanceled };
+    }
+
+    async startTest(request: BlockingRequest): Promise<Empty> {
+        const ctx = restate.useContext(this);
+        const client = new BlockingServiceClientImpl(ctx);
+
+        try {
+            await client.block(request);
+        } catch (e) {
+            if (e instanceof restate.TerminalError && (e as restate.TerminalError).code === restate.ErrorCodes.CANCELLED) {
+                ctx.set("canceled", true);
+            } else {
+                throw e;
+            }
+        }
+
+        return {};
+    }
+
+}
+
+export class BlockingService implements IBlockingService {
+    async block(request: BlockingRequest): Promise<Empty> {
+        const ctx = restate.useContext(this);
+        const client = new AwakeableHolderServiceClientImpl(ctx);
+        const self = new BlockingServiceClientImpl(ctx);
+
+        const { id, promise } = ctx.awakeable();
+        client.hold({ name: "cancel", id })
+        await promise;
+
+        switch (request.operation) {
+            case BlockingOperation.CALL: {
+                await self.block(request);
+                break;
+            }
+            case BlockingOperation.SLEEP: {
+                await ctx.sleep(1_000_000_000);
+                break;
+            }
+            case BlockingOperation.AWAKEABLE: {
+                const { id: _, promise: uncompletable_promise } = ctx.awakeable();
+                await uncompletable_promise;
+                break;
+            }
+        }
+
+        return {};
+    }
+
+    async isUnlocked(request: Empty): Promise<Empty> {
+        return {};
+    }
+}

--- a/tests/src/test/kotlin/dev/restate/e2e/CancelInvocationTest.kt
+++ b/tests/src/test/kotlin/dev/restate/e2e/CancelInvocationTest.kt
@@ -1,0 +1,123 @@
+// Copyright (c) 2023 - Restate Software, Inc., Restate GmbH
+//
+// This file is part of the Restate e2e tests,
+// which are released under the MIT license.
+//
+// You can find a copy of the license in file LICENSE in the root
+// directory of this repository or package, or at
+// https://github.com/restatedev/e2e/blob/main/LICENSE
+
+package dev.restate.e2e
+
+import com.google.protobuf.Empty
+import dev.restate.admin.api.InvocationApi
+import dev.restate.admin.client.ApiClient
+import dev.restate.admin.model.TerminationMode
+import dev.restate.e2e.services.awakeableholder.AwakeableHolderServiceGrpc
+import dev.restate.e2e.services.awakeableholder.hasAwakeableRequest
+import dev.restate.e2e.services.awakeableholder.unlockRequest
+import dev.restate.e2e.services.canceltest.*
+import dev.restate.e2e.services.canceltest.CancelTestProto.BlockingOperation
+import dev.restate.e2e.utils.*
+import dev.restate.generated.IngressGrpc.IngressBlockingStub
+import dev.restate.generated.invokeRequest
+import io.grpc.Channel
+import java.net.URL
+import kotlin.time.Duration.Companion.seconds
+import kotlinx.coroutines.TimeoutCancellationException
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
+import org.awaitility.kotlin.await
+import org.awaitility.kotlin.matches
+import org.awaitility.kotlin.untilCallTo
+import org.junit.jupiter.api.extension.RegisterExtension
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.EnumSource
+
+class JavaCancelInvocationTest : BaseCancelInvocationTest() {
+  companion object {
+    @RegisterExtension
+    val deployerExt: RestateDeployerExtension =
+        RestateDeployerExtension(
+            RestateDeployer.Builder()
+                .withServiceEndpoint(
+                    Containers.javaServicesContainer(
+                        "java-cancel-invocation",
+                        CancelTestServiceGrpc.SERVICE_NAME,
+                        BlockingServiceGrpc.SERVICE_NAME))
+                .withServiceEndpoint(
+                    Containers.nodeServicesContainer(
+                        "awakeable-holder", AwakeableHolderServiceGrpc.SERVICE_NAME))
+                .build())
+  }
+}
+
+class NodeCancelInvocationTest : BaseCancelInvocationTest() {
+  companion object {
+    @RegisterExtension
+    val deployerExt: RestateDeployerExtension =
+        RestateDeployerExtension(
+            RestateDeployer.Builder()
+                .withServiceEndpoint(
+                    Containers.nodeServicesContainer(
+                        "node-cancel-invocation",
+                        CancelTestServiceGrpc.SERVICE_NAME,
+                        BlockingServiceGrpc.SERVICE_NAME,
+                        AwakeableHolderServiceGrpc.SERVICE_NAME))
+                .build())
+  }
+}
+
+abstract class BaseCancelInvocationTest {
+  @ParameterizedTest(name = "cancel blocked invocation on {0}")
+  @EnumSource(
+      value = BlockingOperation::class, names = ["UNRECOGNIZED"], mode = EnumSource.Mode.EXCLUDE)
+  fun cancelInvocation(
+      blockingOperation: BlockingOperation,
+      @InjectBlockingStub ingressClient: IngressBlockingStub,
+      @InjectChannel channel: Channel,
+      @InjectBlockingStub blockingServiceClient: BlockingServiceGrpc.BlockingServiceBlockingStub,
+      @InjectBlockingStub
+      awakeableHolderClient: AwakeableHolderServiceGrpc.AwakeableHolderServiceBlockingStub,
+      @InjectMetaURL metaURL: URL,
+  ) {
+    val request = blockingRequest { operation = blockingOperation }
+
+    val id =
+        ingressClient
+            .invoke(
+                invokeRequest {
+                  service = CancelTestServiceGrpc.SERVICE_NAME
+                  method = CancelTestServiceGrpc.getStartTestMethod().bareMethodName!!
+                  pb = request.toByteString()
+                })
+            .id
+
+    await untilCallTo
+        {
+          awakeableHolderClient.hasAwakeable(hasAwakeableRequest { name = "cancel" })
+        } matches
+        { result ->
+          result!!.hasAwakeable
+        }
+
+    awakeableHolderClient.unlock(unlockRequest { name = "cancel" })
+
+    val client = InvocationApi(ApiClient().setHost(metaURL.host).setPort(metaURL.port))
+    val cancelTestClient = CancelTestServiceGrpcKt.CancelTestServiceCoroutineStub(channel)
+
+    // The termination signal might arrive before the blocking call to the cancel singleton was
+    // made, so we need to retry.
+    await.ignoreException(TimeoutCancellationException::class.java).until {
+      client.terminateInvocation(id, TerminationMode.CANCEL)
+      runBlocking {
+        withTimeout(1.seconds) {
+          cancelTestClient.verifyTest(Empty.getDefaultInstance()).isCanceled
+        }
+      }
+    }
+
+    // Check that the singleton service is unlocked
+    blockingServiceClient.isUnlocked(Empty.getDefaultInstance())
+  }
+}

--- a/tests/src/test/kotlin/dev/restate/e2e/runtime/KillInvocationTest.kt
+++ b/tests/src/test/kotlin/dev/restate/e2e/runtime/KillInvocationTest.kt
@@ -12,6 +12,7 @@ package dev.restate.e2e.runtime
 import com.google.protobuf.Empty
 import dev.restate.admin.api.InvocationApi
 import dev.restate.admin.client.ApiClient
+import dev.restate.admin.model.TerminationMode
 import dev.restate.e2e.Containers
 import dev.restate.e2e.services.awakeableholder.AwakeableHolderServiceGrpc
 import dev.restate.e2e.services.awakeableholder.AwakeableHolderServiceGrpc.AwakeableHolderServiceBlockingStub
@@ -76,7 +77,7 @@ class KillInvocationTest {
 
     // Kill the invocation
     val client = InvocationApi(ApiClient().setHost(metaURL.host).setPort(metaURL.port))
-    client.cancelInvocation(id)
+    client.terminateInvocation(id, TerminationMode.KILL)
 
     // Check that the singleton service is unlocked after killing the call tree
     singletonService.isUnlocked(Empty.getDefaultInstance())


### PR DESCRIPTION
This commit adds new e2e tests which ensure that cancellation works.
The following call chains are canceled:

* CancelTestService/StartTest --> BlockingService/Block --> BlockingSerivce/Block (inboxed call since BlockingService is singleton)
* CancelTestService/StartTest --> BlockingService/Block --> uncompleted awakeable
* CancelTestService/StartTest --> BlockingService/Block --> very long sleep

This fixes https://github.com/restatedev/e2e/issues/228.

For these e2e tests to work, we need to merge the following PRs first:

* https://github.com/restatedev/restate/pull/995
* https://github.com/restatedev/restate/pull/998
* https://github.com/restatedev/service-protocol/pull/59
* https://github.com/restatedev/sdk-typescript/pull/211
* https://github.com/restatedev/restate/pull/1000
* https://github.com/restatedev/sdk-java/pull/188
* https://github.com/restatedev/sdk-java/pull/189