### PR TITLE
Revert "Bump RESTATE_TOKIO_RUNTIME__MAX_BLOCKING_THREADS to 2 for tes…

### DIFF
--- a/tests/build.gradle.kts
+++ b/tests/build.gradle.kts
@@ -94,10 +94,7 @@ tasks {
             mapOf(
                 "RESTATE_WORKER__PARTITIONS" to "1",
                 "RESTATE_TOKIO_RUNTIME__WORKER_THREADS" to "1",
-                // temporary fix for unblocking https://github.com/restatedev/restate/pull/1009,
-                // should be reverted once we have
-                // fixed https://github.com/restatedev/restate/issues/1013
-                "RESTATE_TOKIO_RUNTIME__MAX_BLOCKING_THREADS" to "2",
+                "RESTATE_TOKIO_RUNTIME__MAX_BLOCKING_THREADS" to "1",
             )
 
     useJUnitPlatform {


### PR DESCRIPTION
…tSingleThreadSinglePartition"

This reverts commit 2652fb69e4d74710f3f40d9ea50ca1f41f7b0e8a.

This fixes #239.

This PR should be merged after https://github.com/restatedev/restate/pull/1019 is merged.