### PR TITLE
Disable updateRestateDependency task on CI

### DIFF
--- a/services/node-services/build.gradle.kts
+++ b/services/node-services/build.gradle.kts
@@ -29,7 +29,9 @@ tasks.register<Copy>("prepareDockerBuild") {
 
   if (!System.getenv("SDK_TYPESCRIPT_LOCAL_BUILD").isNullOrEmpty()) {
     dependsOn("installLocalSdkTypescript")
-  } else {
+  } else if (System.getenv("CI").isNullOrEmpty()) {
+    // On CI we don't need to update the restate dependency, this is done implicitly by the e2e
+    // workflow.
     dependsOn("updateRestateDependency")
   }
 


### PR DESCRIPTION
Fix https://github.com/restatedev/e2e/commit/082e023cfca905c7ca2e4ce2e345ef8ad3ef58df#r137148028 and https://github.com/restatedev/e2e/commit/082e023cfca905c7ca2e4ce2e345ef8ad3ef58df#r137148028

What's happening in that test script is that we run `npm install <tar>` from the workflow file first, and then `npm update` from the gradle script, which overwrites the sdk. This seems incorrect.