### PR TITLE
Wait for service availability at the ingress before running tests

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -31,7 +31,7 @@ dependencyResolutionManagement {
       version("protobuf", "3.24.3")
       version("grpc", "1.58.0")
       version("grpckt", "1.4.0")
-      version("log4j", "2.19.0")
+      version("log4j", "2.22.0")
       version("jackson", "2.15.2")
 
       version("junit-jupiter", "5.10.0")

--- a/test-utils/build.gradle.kts
+++ b/test-utils/build.gradle.kts
@@ -37,6 +37,8 @@ dependencies {
   implementation(libs.jackson.databind)
   implementation(libs.jackson.yaml)
 
+  implementation(libs.awaitility)
+
   testImplementation(libs.junit.all)
   testImplementation(libs.assertj)
 }

--- a/test-utils/src/main/kotlin/dev/restate/e2e/utils/JsonUtils.kt
+++ b/test-utils/src/main/kotlin/dev/restate/e2e/utils/JsonUtils.kt
@@ -1,0 +1,43 @@
+// Copyright (c) 2023 - Restate Software, Inc., Restate GmbH
+//
+// This file is part of the Restate e2e tests,
+// which are released under the MIT license.
+//
+// You can find a copy of the license in file LICENSE in the root
+// directory of this repository or package, or at
+// https://github.com/restatedev/e2e/blob/main/LICENSE
+
+package dev.restate.e2e.utils
+
+import com.fasterxml.jackson.databind.JsonNode
+import com.fasterxml.jackson.databind.ObjectMapper
+import java.net.URI
+import java.net.http.HttpClient
+import java.net.http.HttpRequest
+import java.net.http.HttpResponse
+import java.nio.charset.StandardCharsets
+
+object JsonUtils {
+  private val objMapper = ObjectMapper()
+  private val httpClient = HttpClient.newHttpClient()
+
+  fun jacksonBodyHandler(): HttpResponse.BodyHandler<JsonNode> {
+    return HttpResponse.BodyHandler {
+      HttpResponse.BodySubscribers.mapping(
+          HttpResponse.BodySubscribers.ofString(StandardCharsets.UTF_8), objMapper::readTree)
+    }
+  }
+
+  fun jacksonBodyPublisher(value: Any): HttpRequest.BodyPublisher {
+    return HttpRequest.BodyPublishers.ofString(objMapper.writeValueAsString(value))
+  }
+
+  fun postJsonRequest(uri: String, reqBody: Any): HttpResponse<JsonNode> {
+    val req =
+        HttpRequest.newBuilder(URI.create(uri))
+            .headers("Content-Type", "application/json")
+            .POST(jacksonBodyPublisher(reqBody))
+            .build()
+    return httpClient.send(req, jacksonBodyHandler())
+  }
+}

--- a/test-utils/src/main/kotlin/dev/restate/e2e/utils/utils.kt
+++ b/test-utils/src/main/kotlin/dev/restate/e2e/utils/utils.kt
@@ -1,15 +1,19 @@
-// Copyright (c) 2023 - Restate Software, Inc., Restate GmbH
+// Copyright (c) 2024 - Restate Software, Inc., Restate GmbH
 //
-// This file is part of the Restate e2e tests,
-// which are released under the MIT license.
+// This file is part of the Restate Java SDK,
+// which is released under the MIT license.
 //
 // You can find a copy of the license in file LICENSE in the root
 // directory of this repository or package, or at
-// https://github.com/restatedev/e2e/blob/main/LICENSE
+// https://github.com/restatedev/sdk-java/blob/main/LICENSE
 
 package dev.restate.e2e.utils
 
 import com.github.dockerjava.api.command.InspectContainerResponse
+import java.net.URL
+import org.awaitility.kotlin.await
+import org.awaitility.kotlin.matches
+import org.awaitility.kotlin.untilCallTo
 import org.testcontainers.containers.wait.strategy.WaitStrategyTarget
 
 internal open class NotCachedContainerInfo(private val delegate: WaitStrategyTarget) :
@@ -27,5 +31,25 @@ internal class WaitOnSpecificPortsTarget(
 ) : NotCachedContainerInfo(delegate) {
   override fun getExposedPorts(): MutableList<Int> {
     return ports.toMutableList()
+  }
+}
+
+fun waitForServicesBeingAvailable(services: Collection<String>, ingressURL: URL) {
+  val healthCheckURL =
+      URL(
+          ingressURL.protocol,
+          ingressURL.host,
+          ingressURL.port,
+          "/${RestateDeployer.HEALTH_CHECK_SERVICE}")
+
+  for (service in services) {
+    val body = mapOf("service" to service)
+
+    await
+        .untilCallTo { JsonUtils.postJsonRequest(healthCheckURL.toString(), body) }
+        .matches { response ->
+          response!!.statusCode() == 200 &&
+              response!!.body().get("status").asText().equals("SERVING")
+        }
   }
 }

--- a/test-utils/src/main/kotlin/dev/restate/e2e/utils/utils.kt
+++ b/test-utils/src/main/kotlin/dev/restate/e2e/utils/utils.kt
@@ -1,11 +1,11 @@
 // Copyright (c) 2024 - Restate Software, Inc., Restate GmbH
 //
-// This file is part of the Restate Java SDK,
-// which is released under the MIT license.
+// This file is part of the Restate e2e tests,
+// which are released under the MIT license.
 //
 // You can find a copy of the license in file LICENSE in the root
 // directory of this repository or package, or at
-// https://github.com/restatedev/sdk-java/blob/main/LICENSE
+// https://github.com/restatedev/e2e/blob/main/LICENSE
 
 package dev.restate.e2e.utils
 

--- a/tests/src/test/kotlin/dev/restate/e2e/Containers.kt
+++ b/tests/src/test/kotlin/dev/restate/e2e/Containers.kt
@@ -41,7 +41,7 @@ object Containers {
   fun javaServicesContainer(hostName: String, vararg services: String): ServiceSpec.Builder {
     assert(services.isNotEmpty())
     return ServiceSpec.builder("restatedev/e2e-java-services")
-        .withEnv("SERVICES", services.joinToString(","))
+        .withServices(*services)
         .withHostName(hostName)
   }
 
@@ -82,7 +82,7 @@ object Containers {
   fun nodeServicesContainer(hostName: String, vararg services: String): ServiceSpec.Builder {
     assert(services.isNotEmpty())
     return ServiceSpec.builder("restatedev/e2e-node-services")
-        .withEnv("SERVICES", services.joinToString(","))
+        .withServices(*services)
         .withEnv("RESTATE_DEBUG_LOGGING", "JOURNAL")
         .withHostName(hostName)
   }

--- a/tests/src/test/kotlin/dev/restate/e2e/KafkaIngressTest.kt
+++ b/tests/src/test/kotlin/dev/restate/e2e/KafkaIngressTest.kt
@@ -185,11 +185,11 @@ class NodeHandlerAPIKafkaIngressTest {
               HttpRequest.newBuilder(
                       URI.create(
                           "${httpEndpointURL}${Containers.HANDLER_API_COUNTER_SERVICE_NAME}/get"))
-                  .POST(Utils.jacksonBodyPublisher(mapOf("key" to counter)))
+                  .POST(JsonUtils.jacksonBodyPublisher(mapOf("key" to counter)))
                   .headers("Content-Type", "application/json")
                   .build()
 
-          val response = client.send(req, Utils.jacksonBodyHandler())
+          val response = client.send(req, JsonUtils.jacksonBodyHandler())
 
           assertThat(response.statusCode()).isEqualTo(200)
           assertThat(response.headers().firstValue("content-type"))

--- a/tests/src/test/kotlin/dev/restate/e2e/Utils.kt
+++ b/tests/src/test/kotlin/dev/restate/e2e/Utils.kt
@@ -10,38 +10,10 @@
 package dev.restate.e2e
 
 import com.fasterxml.jackson.databind.JsonNode
-import com.fasterxml.jackson.databind.ObjectMapper
-import java.net.URI
-import java.net.http.HttpClient
-import java.net.http.HttpRequest
-import java.net.http.HttpResponse
-import java.nio.charset.StandardCharsets
+import dev.restate.e2e.utils.JsonUtils
 import org.assertj.core.api.Assertions.assertThat
 
 object Utils {
-
-  private val objMapper = ObjectMapper()
-  private val httpClient = HttpClient.newHttpClient()
-
-  fun jacksonBodyHandler(): HttpResponse.BodyHandler<JsonNode> {
-    return HttpResponse.BodyHandler {
-      HttpResponse.BodySubscribers.mapping(
-          HttpResponse.BodySubscribers.ofString(StandardCharsets.UTF_8), objMapper::readTree)
-    }
-  }
-
-  fun jacksonBodyPublisher(value: Any): HttpRequest.BodyPublisher {
-    return HttpRequest.BodyPublishers.ofString(objMapper.writeValueAsString(value))
-  }
-
-  fun postJsonRequest(uri: String, reqBody: Any): HttpResponse<JsonNode> {
-    val req =
-        HttpRequest.newBuilder(URI.create(uri))
-            .headers("Content-Type", "application/json")
-            .POST(jacksonBodyPublisher(reqBody))
-            .build()
-    return httpClient.send(req, jacksonBodyHandler())
-  }
 
   fun doJsonRequestToService(
       restateEndpoint: String,
@@ -49,7 +21,7 @@ object Utils {
       method: String,
       reqBody: Any
   ): JsonNode {
-    val res = postJsonRequest("${restateEndpoint}${service}/${method}", reqBody)
+    val res = JsonUtils.postJsonRequest("${restateEndpoint}${service}/${method}", reqBody)
     assertThat(res.statusCode()).isEqualTo(200)
     assertThat(res.headers().firstValue("content-type"))
         .get()

--- a/tests/src/test/kotlin/dev/restate/e2e/node/EmbeddedHandlerApiTest.kt
+++ b/tests/src/test/kotlin/dev/restate/e2e/node/EmbeddedHandlerApiTest.kt
@@ -15,7 +15,6 @@ import dev.restate.e2e.Containers.EMBEDDED_HANDLER_SERVER_HOSTNAME
 import dev.restate.e2e.Containers.EMBEDDED_HANDLER_SERVER_PORT
 import dev.restate.e2e.Containers.HANDLER_API_COUNTER_SERVICE_NAME
 import dev.restate.e2e.Containers.nodeServicesContainer
-import dev.restate.e2e.Utils.postJsonRequest
 import dev.restate.e2e.utils.*
 import java.net.URL
 import java.util.UUID
@@ -55,7 +54,7 @@ class EmbeddedHandlerApiTest {
 
     for (i in 0..2) {
       val response =
-          postJsonRequest(
+          JsonUtils.postJsonRequest(
               "http://localhost:${embeddedHandlerServerPort}/increment_counter_test",
               mapOf("id" to operationUuid, "input" to counterUuid))
       assertThat(response.statusCode()).isEqualTo(200)
@@ -64,7 +63,7 @@ class EmbeddedHandlerApiTest {
     }
 
     val response =
-        postJsonRequest(
+        JsonUtils.postJsonRequest(
             "${httpEndpointURL}$HANDLER_API_COUNTER_SERVICE_NAME/get", mapOf("key" to counterUuid))
     assertThat(response.statusCode()).isEqualTo(200)
     assertThat(response.body().get("response").get("counter").asInt()).isEqualTo(1)
@@ -100,12 +99,11 @@ class EmbeddedHandlerApiTest {
       @InjectContainerPort(
           hostName = EMBEDDED_HANDLER_SERVER_HOSTNAME, port = EMBEDDED_HANDLER_SERVER_PORT)
       embeddedHandlerServerPort: Int,
-      @InjectGrpcIngressURL httpEndpointURL: URL
   ) {
     val operationUuid = UUID.randomUUID().toString()
 
     val response =
-        postJsonRequest(
+        JsonUtils.postJsonRequest(
             "http://localhost:${embeddedHandlerServerPort}/side_effect_and_awakeable",
             mapOf("id" to operationUuid, "itemsNumber" to 10))
     assertThat(response.statusCode()).isEqualTo(200)
@@ -122,12 +120,11 @@ class EmbeddedHandlerApiTest {
       @InjectContainerPort(
           hostName = EMBEDDED_HANDLER_SERVER_HOSTNAME, port = EMBEDDED_HANDLER_SERVER_PORT)
       embeddedHandlerServerPort: Int,
-      @InjectGrpcIngressURL httpEndpointURL: URL
   ) {
     val operationUuid = UUID.randomUUID().toString()
 
     val response =
-        postJsonRequest(
+        JsonUtils.postJsonRequest(
             "http://localhost:${embeddedHandlerServerPort}/consecutive_side_effects",
             mapOf("id" to operationUuid))
     assertThat(response.statusCode()).isEqualTo(200)
@@ -144,7 +141,7 @@ class EmbeddedHandlerApiTest {
 
     for (i in 0..2) {
       val response =
-          postJsonRequest(
+          JsonUtils.postJsonRequest(
               "http://localhost:${embeddedHandlerServerPort}/${path}",
               mapOf("id" to operationUuid, "input" to counterUuid))
       assertThat(response.statusCode()).isEqualTo(200)
@@ -153,7 +150,7 @@ class EmbeddedHandlerApiTest {
     await untilAsserted
         {
           val response =
-              postJsonRequest(
+              JsonUtils.postJsonRequest(
                   "${httpEndpointURL}$HANDLER_API_COUNTER_SERVICE_NAME/get",
                   mapOf("key" to counterUuid))
           assertThat(response.statusCode()).isEqualTo(200)

--- a/tests/src/test/kotlin/dev/restate/e2e/runtime/ConnectIngressTest.kt
+++ b/tests/src/test/kotlin/dev/restate/e2e/runtime/ConnectIngressTest.kt
@@ -11,10 +11,9 @@ package dev.restate.e2e.runtime
 
 import com.fasterxml.jackson.databind.node.JsonNodeType
 import dev.restate.e2e.Containers
-import dev.restate.e2e.Utils.jacksonBodyHandler
-import dev.restate.e2e.Utils.jacksonBodyPublisher
 import dev.restate.e2e.services.counter.CounterGrpc
 import dev.restate.e2e.utils.InjectGrpcIngressURL
+import dev.restate.e2e.utils.JsonUtils
 import dev.restate.e2e.utils.RestateDeployer
 import dev.restate.e2e.utils.RestateDeployerExtension
 import java.net.URI
@@ -48,11 +47,12 @@ class ConnectIngressTest {
     val req =
         HttpRequest.newBuilder(
                 URI.create("$httpEndpointURL${CounterGrpc.getGetAndAddMethod().fullMethodName}"))
-            .POST(jacksonBodyPublisher(mapOf("counterName" to "my-counter", "value" to 1)))
+            .POST(
+                JsonUtils.jacksonBodyPublisher(mapOf("counterName" to "my-counter", "value" to 1)))
             .headers("Content-Type", "application/json")
             .build()
 
-    val response = client.send(req, jacksonBodyHandler())
+    val response = client.send(req, JsonUtils.jacksonBodyHandler())
 
     assertThat(response.statusCode()).isEqualTo(200)
     assertThat(response.headers().firstValue("content-type"))
@@ -86,11 +86,12 @@ class ConnectIngressTest {
     val req =
         HttpRequest.newBuilder(
                 URI.create("$httpEndpointURL${CounterGrpc.getGetAndAddMethod().fullMethodName}"))
-            .POST(jacksonBodyPublisher(mapOf("counterName" to "my-counter", "value" to 1)))
+            .POST(
+                JsonUtils.jacksonBodyPublisher(mapOf("counterName" to "my-counter", "value" to 1)))
             .headers("Content-Type", "application/whatever")
             .build()
 
-    val response = client.send(req, jacksonBodyHandler())
+    val response = client.send(req, JsonUtils.jacksonBodyHandler())
 
     assertThat(response.statusCode()).isEqualTo(415)
   }
@@ -105,7 +106,7 @@ class ConnectIngressTest {
             .headers("Content-Type", "application/json")
             .build()
 
-    val response = client.send(req, jacksonBodyHandler())
+    val response = client.send(req, JsonUtils.jacksonBodyHandler())
 
     assertThat(response.statusCode()).isEqualTo(400)
   }

--- a/tests/src/test/kotlin/dev/restate/e2e/runtime/IngressServiceTest.kt
+++ b/tests/src/test/kotlin/dev/restate/e2e/runtime/IngressServiceTest.kt
@@ -10,17 +10,12 @@
 package dev.restate.e2e.runtime
 
 import dev.restate.e2e.Containers
-import dev.restate.e2e.Utils.jacksonBodyHandler
-import dev.restate.e2e.Utils.jacksonBodyPublisher
 import dev.restate.e2e.services.counter.CounterGrpc
 import dev.restate.e2e.services.counter.CounterGrpc.CounterBlockingStub
 import dev.restate.e2e.services.counter.CounterProto.*
 import dev.restate.e2e.services.counter.counterAddRequest
 import dev.restate.e2e.services.counter.counterRequest
-import dev.restate.e2e.utils.InjectBlockingStub
-import dev.restate.e2e.utils.InjectGrpcIngressURL
-import dev.restate.e2e.utils.RestateDeployer
-import dev.restate.e2e.utils.RestateDeployerExtension
+import dev.restate.e2e.utils.*
 import dev.restate.generated.IngressGrpc.IngressBlockingStub
 import dev.restate.generated.invokeRequest
 import io.grpc.Metadata
@@ -67,7 +62,7 @@ class IngressServiceTest {
     val req =
         HttpRequest.newBuilder(URI.create("${httpEndpointURL}dev.restate.Ingress/Invoke"))
             .POST(
-                jacksonBodyPublisher(
+                JsonUtils.jacksonBodyPublisher(
                     mapOf(
                         "service" to CounterGrpc.SERVICE_NAME,
                         "method" to CounterGrpc.getAddMethod().bareMethodName,
@@ -75,7 +70,7 @@ class IngressServiceTest {
             .headers("Content-Type", "application/json")
             .build()
 
-    val response = client.send(req, jacksonBodyHandler())
+    val response = client.send(req, JsonUtils.jacksonBodyHandler())
 
     assertThat(response.statusCode()).isEqualTo(200)
     assertThat(response.headers().firstValue("content-type"))

--- a/tests/src/test/kotlin/dev/restate/e2e/runtime/PrivateServiceTest.kt
+++ b/tests/src/test/kotlin/dev/restate/e2e/runtime/PrivateServiceTest.kt
@@ -24,13 +24,11 @@ import dev.restate.e2e.utils.*
 import io.grpc.StatusRuntimeException
 import java.net.URL
 import java.util.UUID
-import java.util.concurrent.TimeUnit
 import org.assertj.core.api.Assertions.*
 import org.assertj.core.api.InstanceOfAssertFactories.type
 import org.awaitility.kotlin.await
 import org.awaitility.kotlin.untilAsserted
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.Timeout
 import org.junit.jupiter.api.extension.RegisterExtension
 
 /** Test supporting private services */
@@ -45,7 +43,6 @@ class PrivateServiceTest {
                 .build())
   }
 
-  @Timeout(value = 30, unit = TimeUnit.SECONDS)
   @Test
   fun privateService(
       @InjectMetaURL metaURL: URL,

--- a/tests/src/test/kotlin/dev/restate/e2e/runtime/RetryOnUnknownServiceTest.kt
+++ b/tests/src/test/kotlin/dev/restate/e2e/runtime/RetryOnUnknownServiceTest.kt
@@ -48,13 +48,14 @@ class RetryOnUnknownServiceTest {
           .build()
     }
 
-    fun registerListService(metaURL: URL) {
+    fun registerListService(metaURL: URL, ingressURL: URL) {
       val client = DeploymentApi(ApiClient().setHost(metaURL.host).setPort(metaURL.port))
       client.createDeployment(
           RegisterDeploymentRequest(
               RegisterDeploymentRequestAnyOf()
                   .uri("http://${Containers.NODE_COLLECTIONS_SERVICE_SPEC.hostName}:8080/")
                   .force(false)))
+      waitForServicesBeingAvailable(Containers.NODE_COLLECTIONS_SERVICE_SPEC.services, ingressURL)
     }
   }
 
@@ -63,13 +64,15 @@ class RetryOnUnknownServiceTest {
       @InjectBlockingStub ingressClient: IngressBlockingStub,
       @InjectBlockingStub proxyServiceGrpc: ProxyServiceBlockingStub,
       @InjectBlockingStub listClient: ListServiceBlockingStub,
-      @InjectMetaURL metaURL: URL
+      @InjectMetaURL metaURL: URL,
+      @InjectGrpcIngressURL ingressURL: URL,
   ) {
     retryOnUnknownTest(
         ingressClient,
         proxyServiceGrpc,
         listClient,
         metaURL,
+        ingressURL,
         ProxyServiceGrpc.getCallMethod().bareMethodName!!)
   }
 
@@ -78,13 +81,15 @@ class RetryOnUnknownServiceTest {
       @InjectBlockingStub ingressClient: IngressBlockingStub,
       @InjectBlockingStub proxyServiceGrpc: ProxyServiceBlockingStub,
       @InjectBlockingStub listClient: ListServiceBlockingStub,
-      @InjectMetaURL metaURL: URL
+      @InjectMetaURL metaURL: URL,
+      @InjectGrpcIngressURL ingressURL: URL,
   ) {
     retryOnUnknownTest(
         ingressClient,
         proxyServiceGrpc,
         listClient,
         metaURL,
+        ingressURL,
         ProxyServiceGrpc.getOneWayCallMethod().bareMethodName!!)
   }
 
@@ -93,6 +98,7 @@ class RetryOnUnknownServiceTest {
       proxyServiceGrpc: ProxyServiceBlockingStub,
       listClient: ListServiceBlockingStub,
       metaURL: URL,
+      ingressURL: URL,
       methodName: String
   ) {
     val list = UUID.randomUUID().toString()
@@ -126,7 +132,7 @@ class RetryOnUnknownServiceTest {
         }
 
     // Register list service
-    registerListService(metaURL)
+    registerListService(metaURL, ingressURL)
 
     // Let's wait for the list service to contain "a" once
     await untilAsserted

--- a/tests/src/test/resources/junit-platform.properties
+++ b/tests/src/test/resources/junit-platform.properties
@@ -1,5 +1,5 @@
 # Timeout config
-junit.jupiter.execution.timeout.testable.method.default=10 s
+junit.jupiter.execution.timeout.testable.method.default=15 s
 junit.jupiter.execution.timeout.lifecycle.method.default=1 m
 
 # Parallelism config

--- a/tests/src/test/resources/junit-platform.properties
+++ b/tests/src/test/resources/junit-platform.properties
@@ -1,5 +1,5 @@
 # Timeout config
-junit.jupiter.execution.timeout.testable.method.default=15 s
+junit.jupiter.execution.timeout.testable.method.default=10 s
 junit.jupiter.execution.timeout.lifecycle.method.default=1 m
 
 # Parallelism config


### PR DESCRIPTION
This commit makes the RestateDeployer wait for the availability of registered
services at the ingress. The deployer checks whether the ingress is serving
the registered services via calling grpc.health.v1.Health/Check and checking
that the response contains status = SERVING.

This fixes https://github.com/restatedev/e2e/issues/266.