### PR TITLE
Disable e2e tests which require durability from the runtime

### DIFF
--- a/tests/src/test/kotlin/dev/restate/e2e/node/VerificationTest.kt
+++ b/tests/src/test/kotlin/dev/restate/e2e/node/VerificationTest.kt
@@ -30,10 +30,7 @@ import kotlin.time.Duration.Companion.seconds
 import kotlin.time.toJavaDuration
 import org.apache.logging.log4j.LogManager
 import org.awaitility.kotlin.*
-import org.junit.jupiter.api.DisplayName
-import org.junit.jupiter.api.Tag
-import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.Timeout
+import org.junit.jupiter.api.*
 import org.junit.jupiter.api.extension.RegisterExtension
 
 @Tag("always-suspending")
@@ -121,6 +118,8 @@ class VerificationTest {
     verifier.clear(clearRequest { params = testParams })
   }
 
+  @Disabled(
+      "Disabled until we have durable loglet implementation. See https://github.com/restatedev/restate/issues/875")
   @Timeout(value = 1, unit = TimeUnit.MINUTES)
   @Test
   fun killingTheRuntime(
@@ -140,6 +139,8 @@ class VerificationTest {
     verifier.clear(clearRequest { params = testParams })
   }
 
+  @Disabled(
+      "Disabled until we have durable loglet implementation. See https://github.com/restatedev/restate/issues/875")
   @Timeout(value = 1, unit = TimeUnit.MINUTES)
   @Test
   fun stoppingTheRuntime(

--- a/tests/src/test/kotlin/dev/restate/e2e/runtime/PersistenceTest.kt
+++ b/tests/src/test/kotlin/dev/restate/e2e/runtime/PersistenceTest.kt
@@ -29,6 +29,8 @@ class PersistenceTest {
     }
   }
 
+  @Disabled(
+      "Disabled until we have durable loglet implementation. See https://github.com/restatedev/restate/issues/875")
   @Timeout(value = 30, unit = TimeUnit.SECONDS)
   @Test
   fun startAndStopRuntimeRetainsTheState(
@@ -51,6 +53,8 @@ class PersistenceTest {
     assertThat(res2.newValue).isEqualTo(3)
   }
 
+  @Disabled(
+      "Disabled until we have durable loglet implementation. See https://github.com/restatedev/restate/issues/875")
   @Timeout(value = 30, unit = TimeUnit.SECONDS)
   @Test
   fun startAndKillRuntimeRetainsTheState(

--- a/tests/src/test/kotlin/dev/restate/e2e/runtime/UpgradeServiceTest.kt
+++ b/tests/src/test/kotlin/dev/restate/e2e/runtime/UpgradeServiceTest.kt
@@ -30,6 +30,7 @@ import org.awaitility.kotlin.await
 import org.awaitility.kotlin.matches
 import org.awaitility.kotlin.untilAsserted
 import org.awaitility.kotlin.untilCallTo
+import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.RegisterExtension
@@ -101,6 +102,8 @@ class UpgradeServiceTest {
         ingressClient, upgradeTestClient, awakeableHolderClient, listClient, metaURL)
   }
 
+  @Disabled(
+      "Disabled until we have durable loglet implementation. See https://github.com/restatedev/restate/issues/875")
   @Test
   fun inFlightInvocationStoppingTheRuntime(
       @InjectBlockingStub ingressClient: IngressGrpc.IngressBlockingStub,


### PR DESCRIPTION
This commit disables the following tests which require durability:

* PersistenceTest.startAndStopRuntimeRetainsTheState
* PersistenceTest.startAndKillRuntimeRetainsTheState
* VerificationTest.killingTheRuntime
* VerificationTest.stoppingTheRuntime
* UpgradeServiceTest.inFlightInvocationStoppingTheRuntime

This fixes #273.