### PR TITLE
Adjust the typescript e2e tests after API refactor

### DIFF
--- a/services/node-services/src/awakeable_holder.ts
+++ b/services/node-services/src/awakeable_holder.ts
@@ -18,10 +18,10 @@ type Ctx = restate.ObjectContext;
 
 REGISTRY.add({
   fqdn: AwakeableHolderServiceFQN,
-  binder: (e) => e.object(AwakeableHolderServiceFQN, service),
+  binder: (e) => e.object(service),
 });
 
-const service = restate.object({
+const service = restate.object(AwakeableHolderServiceFQN, {
   async hold(ctx: restate.ObjectContext, id: string) {
     ctx.set(ID_KEY, id);
   },
@@ -41,7 +41,4 @@ const service = restate.object({
   },
 });
 
-export const awakeableHolderApi = restate.objectApi(
-  AwakeableHolderServiceFQN,
-  service
-);
+export type awakeableHolderApi = typeof service;

--- a/services/node-services/src/counter.ts
+++ b/services/node-services/src/counter.ts
@@ -9,7 +9,7 @@
 
 import * as restate from "@restatedev/restate-sdk";
 import { REGISTRY } from "./services";
-import { awakeableHolderApi } from "./awakeable_holder";
+import type { awakeableHolderApi } from "./awakeable_holder";
 
 const COUNTER_KEY = "counter";
 
@@ -17,10 +17,12 @@ export const CounterServiceFQN = "Counter";
 
 REGISTRY.add({
   fqdn: CounterServiceFQN,
-  binder: (e) => e.object(CounterServiceFQN, service),
+  binder: (e) => e.object(service),
 });
 
-const service = restate.object({
+const AwakeableHolder: awakeableHolderApi = { path: "AwakeableHolder" };
+
+const service = restate.object(CounterServiceFQN, {
   async reset(ctx: restate.ObjectContext) {
     ctx.clear(COUNTER_KEY);
   },
@@ -56,7 +58,7 @@ const service = restate.object({
 
     // Wait for the sync with the test runner
     const { id, promise } = ctx.awakeable();
-    ctx.objectSend(awakeableHolderApi, ctx.key()).hold(id);
+    ctx.objectSend(AwakeableHolder, ctx.key()).hold(id);
     await promise;
 
     // Now start looping
@@ -74,4 +76,4 @@ const service = restate.object({
   },
 });
 
-export const counterApi = restate.objectApi(CounterServiceFQN, service);
+export type counterApi = typeof service;

--- a/services/node-services/src/event_handler.ts
+++ b/services/node-services/src/event_handler.ts
@@ -13,13 +13,15 @@ import { counterApi } from "./counter";
 
 const EventHandlerFQN = "EventHandler";
 
+const CounterApi: counterApi = { path: "Counter" };
+
 REGISTRY.add({
   fqdn: EventHandlerFQN,
-  binder: (e) => e.object(EventHandlerFQN, service),
+  binder: (e) => e.object(service),
 });
 
-const service = restate.object({
+const service = restate.object(EventHandlerFQN, {
   async handle(ctx: restate.ObjectContext, value: number) {
-    ctx.objectSend(counterApi, ctx.key()).add(value);
+    ctx.objectSend(CounterApi, ctx.key()).add(value);
   },
 });

--- a/services/node-services/src/list.ts
+++ b/services/node-services/src/list.ts
@@ -16,10 +16,10 @@ const ListServiceFQN = "ListObject";
 
 REGISTRY.add({
   fqdn: ListServiceFQN,
-  binder: (e) => e.object(ListServiceFQN, service),
+  binder: (e) => e.object(service),
 });
 
-const service = restate.object({
+const service = restate.object(ListServiceFQN, {
   async append(ctx: restate.ObjectContext, request: string): Promise<void> {
     const list = (await ctx.get<string[]>(LIST_KEY)) ?? [];
     list.push(request);

--- a/services/node-services/src/map.ts
+++ b/services/node-services/src/map.ts
@@ -13,10 +13,10 @@ export const MapServiceFQN = "MapObject";
 
 REGISTRY.add({
   fqdn: MapServiceFQN,
-  binder: (e) => e.object(MapServiceFQN, service),
+  binder: (e) => e.object(service),
 });
 
-const service = restate.object({
+const service = restate.object(MapServiceFQN, {
   async clearAll(ctx: restate.ObjectContext): Promise<string[]> {
     const keys = await ctx.stateKeys();
     ctx.clearAll();

--- a/services/node-services/src/proxy_counter.ts
+++ b/services/node-services/src/proxy_counter.ts
@@ -12,18 +12,19 @@ import { REGISTRY } from "./services";
 import { counterApi } from "./counter";
 
 const ProxyCounterServiceFQN = "ProxyCounter";
+const Counter: counterApi = { path: "Counter" };
 
 REGISTRY.add({
   fqdn: ProxyCounterServiceFQN,
-  binder: (e) => e.service(ProxyCounterServiceFQN, service),
+  binder: (e) => e.service(service),
 });
 
-const service = restate.service({
+const service = restate.service(ProxyCounterServiceFQN, {
   async addInBackground(
     ctx: restate.Context,
     request: { counterName: string; value: number }
   ) {
     ctx.console.log("addInBackground " + JSON.stringify(request));
-    ctx.objectSend(counterApi, request.counterName).add(request.value);
+    ctx.objectSend(Counter, request.counterName).add(request.value);
   },
 });


### PR DESCRIPTION
This PR adjusts the e2e tests following the removal of `objectApi` and `serviceApi` types.
