### PR TITLE
[interpreter] Next version of the verification test

### DIFF
--- a/services/node-services/src/app.ts
+++ b/services/node-services/src/app.ts
@@ -22,6 +22,7 @@ import "./non_determinism";
 import "./random_number_list";
 import "./failing";
 import "./side_effect";
+import "./interpreter/entry_point";
 
 import { REGISTRY } from "./services";
 

--- a/services/node-services/src/interpreter/commands.ts
+++ b/services/node-services/src/interpreter/commands.ts
@@ -1,0 +1,149 @@
+// Copyright (c) 2023 - Restate Software, Inc., Restate GmbH
+//
+// This file is part of the Restate e2e tests,
+// which are released under the MIT license.
+//
+// You can find a copy of the license in file LICENSE in the root
+// directory of this repository or package, or at
+// https://github.com/restatedev/e2e/blob/main/LICENSE
+
+/// Command AST
+
+export enum CommandType {
+  SET_STATE = 1,
+  GET_STATE = 2,
+  CLEAR_STATE = 3,
+  INCREMENT_STATE_COUNTER = 4,
+  INCREMENT_STATE_COUNTER_INDIRECTLY = 5,
+  SLEEP = 6,
+  CALL_SERVICE = 7,
+  CALL_SLOW_SERVICE = 8,
+  INCREMENT_VIA_DELAYED_CALL = 9,
+  SIDE_EFFECT = 10,
+  THROWING_SIDE_EFFECT = 11,
+  SLOW_SIDE_EFFECT = 12,
+  RECOVER_TERMINAL_CALL = 13,
+  RECOVER_TERMINAL_MAYBE_UN_AWAITED = 14,
+  AWAIT_PROMISE = 15,
+  RESOLVE_AWAKEABLE = 16,
+  REJECT_AWAKEABLE = 17,
+  INCREMENT_STATE_COUNTER_VIA_AWAKEABLE = 18,
+  CALL_NEXT_LAYER_OBJECT = 19,
+}
+
+export type Command =
+  | SetState
+  | GetState
+  | ClearState
+  | IncrementStateCounter
+  | Sleep
+  | CallService
+  | IncrementViaDelayedCall
+  | SideEffect
+  | SlowSideEffect
+  | CallSlowService
+  | RecoverTerminalCall
+  | RecoverTerminalCallMaybeUnAwaited
+  | ThrowingSideEffect
+  | IncrementStateCounterIndirectly
+  | AwaitPromise
+  | ResolveAwakeable
+  | RejectAwakeable
+  | IncrementStateCounterViaAwakeable
+  | CallObject;
+
+export type Program = {
+  commands: Command[];
+};
+
+//
+// no parameters
+//
+export type IncrementStateCounter = {
+  kind: CommandType.INCREMENT_STATE_COUNTER;
+};
+
+export type RecoverTerminalCall = {
+  kind: CommandType.RECOVER_TERMINAL_CALL;
+};
+
+export type RecoverTerminalCallMaybeUnAwaited = {
+  kind: CommandType.RECOVER_TERMINAL_MAYBE_UN_AWAITED;
+};
+
+export type ThrowingSideEffect = {
+  kind: CommandType.THROWING_SIDE_EFFECT;
+};
+
+export type SlowSideEffect = {
+  kind: CommandType.SLOW_SIDE_EFFECT;
+};
+
+export type IncrementStateCounterIndirectly = {
+  kind: CommandType.INCREMENT_STATE_COUNTER_INDIRECTLY;
+};
+
+export type ResolveAwakeable = {
+  kind: CommandType.RESOLVE_AWAKEABLE;
+};
+
+export type RejectAwakeable = {
+  kind: CommandType.REJECT_AWAKEABLE;
+};
+
+export type IncrementStateCounterViaAwakeable = {
+  kind: CommandType.INCREMENT_STATE_COUNTER_VIA_AWAKEABLE;
+};
+
+export type CallService = {
+  kind: CommandType.CALL_SERVICE;
+};
+
+export type SideEffect = {
+  kind: CommandType.SIDE_EFFECT;
+};
+
+// state
+
+export type GetState = {
+  kind: CommandType.GET_STATE;
+  key: number;
+};
+
+export type ClearState = {
+  kind: CommandType.CLEAR_STATE;
+  key: number;
+};
+
+export type SetState = {
+  kind: CommandType.SET_STATE;
+  key: number;
+};
+
+// special
+
+export type Sleep = {
+  kind: CommandType.SLEEP;
+  duration: number;
+};
+
+export type IncrementViaDelayedCall = {
+  kind: CommandType.INCREMENT_VIA_DELAYED_CALL;
+  duration: number;
+};
+
+export type AwaitPromise = {
+  kind: CommandType.AWAIT_PROMISE;
+  index: number;
+};
+
+export type CallSlowService = {
+  kind: CommandType.CALL_SLOW_SERVICE;
+  sleep: number;
+};
+
+export type CallObject = {
+  kind: CommandType.CALL_NEXT_LAYER_OBJECT;
+  key: number;
+  program: Program;
+};

--- a/services/node-services/src/interpreter/driver.ts
+++ b/services/node-services/src/interpreter/driver.ts
@@ -1,0 +1,109 @@
+// Copyright (c) 2023 - Restate Software, Inc., Restate GmbH
+//
+// This file is part of the Restate e2e tests,
+// which are released under the MIT license.
+//
+// You can find a copy of the license in file LICENSE in the root
+// directory of this repository or package, or at
+// https://github.com/restatedev/e2e/blob/main/LICENSE
+
+import * as http from "node:http";
+import { Test, TestConfiguration, TestStatus } from "./test_driver";
+
+let TEST: Test | undefined = undefined;
+
+/**
+ * Start a runner as a batch job
+ */
+export const createJob = async () => {
+  const conf = await readJSONFromStdin();
+  TEST = new Test(conf);
+  return TEST.go();
+};
+
+/**
+ * Start a webserver
+ */
+export const createServer = (port: number) => {
+  http
+    .createServer(async function (req, res) {
+      const url = req.url ?? "/";
+      if (url === "/start" && req.method === "POST") {
+        const conf = await readJson<TestConfiguration>(req);
+        const status = TEST?.testStatus() ?? TestStatus.NOT_STARTED;
+
+        if (status !== TestStatus.NOT_STARTED) {
+          writeJsonResponse(400, { status }, res);
+          return;
+        }
+
+        TEST = new Test(conf);
+        TEST.go().catch((e) => console.log(e));
+
+        writeJsonResponse(200, { status: TEST.testStatus() }, res);
+      } else if (url === "/status") {
+        writeJsonResponse(
+          200,
+          { status: TEST?.testStatus() ?? TestStatus.NOT_STARTED },
+          res
+        );
+      } else if (url === "/sample") {
+        const conf = await readJson<TestConfiguration>(req);
+        const test = new Test(conf);
+        const generator = test.generate();
+        const itemSafe = generator.next();
+        if (!itemSafe.done) {
+          const { program } = itemSafe.value;
+          writeJsonResponse(200, program, res);
+        } else {
+          writeJsonResponse(
+            400,
+            { cause: "please specify at least one test" },
+            res
+          );
+        }
+      } else {
+        writeJsonResponse(404, {}, res);
+      }
+    })
+    .listen(port);
+};
+
+async function readJson<T>(req: http.IncomingMessage): Promise<T> {
+  let data = "";
+  for await (const chunk of req) {
+    data += chunk;
+  }
+  return JSON.parse(data) as T;
+}
+
+function writeJsonResponse(
+  code: number,
+  body: unknown,
+  res: http.ServerResponse<http.IncomingMessage>
+) {
+  res.writeHead(code, { "Content-Type": "application/json" });
+  res.write(JSON.stringify(body));
+  res.end();
+}
+
+function readJSONFromStdin(): Promise<TestConfiguration> {
+  return new Promise((resolve, reject) => {
+    let input = "";
+    process.stdin.setEncoding("utf-8");
+    process.stdin.on("readable", () => {
+      const chunk = process.stdin.read();
+      if (chunk !== null) {
+        input += chunk;
+      }
+    });
+    process.stdin.on("end", () => {
+      try {
+        const jsonData: TestConfiguration = JSON.parse(input.trim());
+        resolve(jsonData);
+      } catch (error) {
+        reject(error);
+      }
+    });
+  });
+}

--- a/services/node-services/src/interpreter/entry_point.ts
+++ b/services/node-services/src/interpreter/entry_point.ts
@@ -1,0 +1,55 @@
+// Copyright (c) 2023 - Restate Software, Inc., Restate GmbH
+//
+// This file is part of the Restate e2e tests,
+// which are released under the MIT license.
+//
+// You can find a copy of the license in file LICENSE in the root
+// directory of this repository or package, or at
+// https://github.com/restatedev/e2e/blob/main/LICENSE
+
+import { REGISTRY } from "../services";
+import { createInterpreterObject } from "./interpreter";
+import { serviceInterpreterHelper } from "./services";
+import { createServer, createJob } from "./driver";
+
+/**
+ * Hardcode for now, the Max number of InterpreterObject layers.
+ * Each layer is represented by a VirtualObject that implements the ObjectInterpreter interface,
+ * And named: `ObjectInterpreterL${layer}.
+ *
+ * i.e. (for 3 layers we get):
+ *
+ * ObjectInterpreterL0, ObjectInterpreterL1,ObjectInterpreterL2
+ *
+ * Each ObjectInterpreter is only allowed to preform blocking calls to the next layer,
+ * to avoid deadlocks.
+ *
+ */
+
+REGISTRY.addService(serviceInterpreterHelper);
+REGISTRY.addObject(createInterpreterObject(0));
+REGISTRY.addObject(createInterpreterObject(1));
+REGISTRY.addObject(createInterpreterObject(2));
+
+REGISTRY.add({
+  fqdn: "InterpreterDriver",
+  binder: () => {
+    const port = process.env.INTERPRETER_DRIVER_PORT ?? "3000";
+    createServer(parseInt(port));
+  },
+});
+
+REGISTRY.add({
+  fqdn: "InterpreterDriverJob",
+  binder: () => {
+    createJob()
+      .then((status) => {
+        console.log(`Job success! ${status}`);
+        process.exit(0);
+      })
+      .catch((e) => {
+        console.log(`Job failure ${e}`);
+        process.exit(1);
+      });
+  },
+});

--- a/services/node-services/src/interpreter/interpreter.ts
+++ b/services/node-services/src/interpreter/interpreter.ts
@@ -1,0 +1,272 @@
+// Copyright (c) 2023 - Restate Software, Inc., Restate GmbH
+//
+// This file is part of the Restate e2e tests,
+// which are released under the MIT license.
+//
+// You can find a copy of the license in file LICENSE in the root
+// directory of this repository or package, or at
+// https://github.com/restatedev/e2e/blob/main/LICENSE
+
+import * as restate from "@restatedev/restate-sdk";
+import { CommandType, Program } from "./commands";
+import type { ServiceInterpreterHelper as Service } from "./services";
+
+export type InterpreterId = {
+  readonly layer: number;
+  readonly key: string;
+};
+
+export const interpreterObjectForLayer = (
+  layer: number
+): restate.VirtualObjectDefinition<
+  string,
+  restate.VirtualObject<InterpreterObject>
+> => {
+  const name = `ObjectInterpreterL${layer}`;
+  return { name };
+};
+
+export const createInterpreterObject = (layer: number) => {
+  const name = `ObjectInterpreterL${layer}`;
+
+  const handlers: InterpreterObject = {
+    counter: async (ctx: restate.ObjectContext): Promise<number> => {
+      return (await ctx.get(STATE_COUNTER_NAME)) ?? 0;
+    },
+
+    interpret: (
+      ctx: restate.ObjectContext,
+      program: Program
+    ): Promise<void> => {
+      return ProgramInterpreter.from(layer, ctx).interpret(program);
+    },
+  };
+
+  return restate.object({ name, handlers });
+};
+
+interface InterpreterObject {
+  counter(ctx: restate.ObjectContext): Promise<number>;
+  interpret(ctx: restate.ObjectContext, program: Program): Promise<void>;
+}
+
+/**
+ * Represents a promise to be awaited on.
+ * we delay *any* chaining to the promise as close as possible
+ * to the moment that promise is being awaited, because sometimes chaining
+ * might actually create a side effect (for example trigger a suspension timer).
+ *
+ * There is also an expected value to verify that the result of the promise strictly matches to the expected value.
+ */
+type Await = {
+  readonly expected?: string;
+  readonly thunk: () => Promise<string> | Promise<void>;
+};
+
+const Service: Service = { name: "ServiceInterpreterHelper" };
+const STATE_COUNTER_NAME = "counter";
+
+class ProgramInterpreter {
+  public static from(
+    layer: number,
+    ctx: restate.ObjectContext
+  ): ProgramInterpreter {
+    const id = { layer, key: ctx.key() };
+    return new ProgramInterpreter(ctx, id);
+  }
+
+  constructor(
+    private readonly ctx: restate.ObjectContext,
+    private readonly interpreterId: InterpreterId
+  ) {}
+
+  async interpret(program: Program): Promise<void> {
+    const ctx = this.ctx;
+    const promises = new Map<number, Await>();
+    const commands = program.commands;
+    for (let i = 0; i < commands.length; i++) {
+      const command = commands[i];
+      switch (command.kind) {
+        case CommandType.SET_STATE: {
+          ctx.set(`key-${command.key}`, `value-${command.key}`);
+          break;
+        }
+        case CommandType.GET_STATE: {
+          await ctx.get(`key-${command.key}`);
+          break;
+        }
+        case CommandType.CLEAR_STATE: {
+          ctx.clear(`key-${command.key}`);
+          break;
+        }
+        case CommandType.INCREMENT_STATE_COUNTER: {
+          const counter = (await ctx.get<number>(STATE_COUNTER_NAME)) ?? 0;
+          ctx.set(STATE_COUNTER_NAME, counter + 1);
+          break;
+        }
+        case CommandType.SLEEP: {
+          await ctx.sleep(command.duration);
+          break;
+        }
+        case CommandType.CALL_SERVICE: {
+          const expected = `hello-${i}`;
+          const promise = ctx.serviceClient(Service).echo(expected);
+          promises.set(i, {
+            thunk: () => promise,
+            expected,
+          });
+          break;
+        }
+        case CommandType.INCREMENT_VIA_DELAYED_CALL: {
+          ctx
+            .serviceSendClient(Service, { delay: command.duration })
+            .incrementIndirectly(this.interpreterId);
+          break;
+        }
+        case CommandType.CALL_SLOW_SERVICE: {
+          const expected = `hello-${i}`;
+          const promise = ctx.serviceClient(Service).echoLater({
+            sleep: command.sleep,
+            parameter: expected,
+          });
+          promises.set(i, {
+            thunk: () => promise,
+            expected,
+          });
+          break;
+        }
+        case CommandType.SIDE_EFFECT: {
+          const expected = `hello-${i}`;
+          const result = await ctx.run(() => expected);
+          if (result !== expected) {
+            throw new restate.TerminalError(
+              `RPC failure ${result} != ${expected}`
+            );
+          }
+          break;
+        }
+        case CommandType.SLOW_SIDE_EFFECT: {
+          await ctx.run(
+            () =>
+              new Promise((resolve) => {
+                setTimeout(resolve, 1);
+              })
+          );
+          break;
+        }
+        case CommandType.RECOVER_TERMINAL_CALL: {
+          const promise = ctx.serviceClient(Service).terminalFailure();
+          let caught = false;
+          try {
+            await promise;
+          } catch (e) {
+            if (e instanceof restate.TerminalError) {
+              caught = true;
+            }
+          }
+          if (!caught) {
+            throw new restate.TerminalError(
+              `Test assertion failed, was expected to get a terminal error.`
+            );
+          }
+          break;
+        }
+        case CommandType.RECOVER_TERMINAL_MAYBE_UN_AWAITED: {
+          const promise = ctx.serviceClient(Service).terminalFailure();
+          promises.set(i, {
+            thunk: () => promise.catch(() => "terminal"),
+            expected: "terminal",
+          });
+          // failed and unchained promises in Node will cause the process to exit.
+          promise.catch(() => {
+            /* safety */
+          });
+          break;
+        }
+        case CommandType.THROWING_SIDE_EFFECT: {
+          await ctx.run(() => {
+            if (Math.random() < 0.5) {
+              throw new TypeError(
+                "undefined is not a number, but it still has feelings."
+              );
+            }
+          });
+          break;
+        }
+        case CommandType.INCREMENT_STATE_COUNTER_INDIRECTLY: {
+          ctx
+            .serviceSendClient(Service)
+            .incrementIndirectly(this.interpreterId);
+          break;
+        }
+        case CommandType.AWAIT_PROMISE: {
+          const index = command.index;
+          const toAwait = promises.get(index);
+          if (!toAwait) {
+            // Unexpected. This can be an interpreter bug, and can be a real issue.
+            // Not very helpful I know :( but this is truly unexpected to have happen.
+            throw new restate.TerminalError(
+              `ObjectInterpreter: can not find a promise for the id ${index}.`
+            );
+          }
+          promises.delete(index);
+          const { thunk, expected } = toAwait;
+          const result = await thunk();
+          if (result !== expected) {
+            const originalCommandWas = commands[index];
+            throw new restate.TerminalError(
+              `Awaited promise mismatch. got ${result}  expected ${expected} ; command ${originalCommandWas}`
+            );
+          }
+          break;
+        }
+        case CommandType.RESOLVE_AWAKEABLE: {
+          const { id, promise } = ctx.awakeable<string>();
+          promises.set(i, { thunk: () => promise, expected: "ok" });
+          ctx.serviceSendClient(Service).resolveAwakeable(id);
+          break;
+        }
+        case CommandType.REJECT_AWAKEABLE: {
+          const { id, promise } = ctx.awakeable<string>();
+          promises.set(i, {
+            thunk: () => promise.catch(() => "rejected"),
+            expected: "rejected",
+          });
+          // failed and unchained promises in Node will cause the process to exit.
+          promise.catch(() => {
+            /* safety */
+          });
+          ctx.serviceSendClient(Service).rejectAwakeable(id);
+          break;
+        }
+        case CommandType.INCREMENT_STATE_COUNTER_VIA_AWAKEABLE: {
+          // there is a complicated dance here.
+          const { id: txPromiseId, promise: txPromise } =
+            ctx.awakeable<string>();
+          ctx.serviceSendClient(Service).incrementViaAwakeableDance({
+            interpreter: this.interpreterId,
+            txPromiseId,
+          });
+          // wait for the helper service to give us a promise to resolve.
+          const theirPromiseIdForUsToResolve = await txPromise;
+          // let us resolve it
+          ctx.resolveAwakeable(theirPromiseIdForUsToResolve, "ok");
+          break;
+        }
+        case CommandType.CALL_NEXT_LAYER_OBJECT: {
+          const nextLayer = this.interpreterId.layer + 1;
+          const key = `${command.key}`;
+          const def = interpreterObjectForLayer(nextLayer);
+
+          const program = command.program;
+          const promise = ctx.objectClient(def, key).interpret(program);
+          promises.set(i, { thunk: () => promise });
+          // safety: we must at least add a catch handler otherwise if the call results with a terminal exception propagated
+          // and Node will cause this process to exit.
+          promise.catch(() => {});
+          break;
+        }
+      }
+    }
+  }
+}

--- a/services/node-services/src/interpreter/random.ts
+++ b/services/node-services/src/interpreter/random.ts
@@ -1,0 +1,107 @@
+// Copyright (c) 2023 - Restate Software, Inc., Restate GmbH
+//
+// This file is part of the Restate e2e tests,
+// which are released under the MIT license.
+//
+// You can find a copy of the license in file LICENSE in the root
+// directory of this repository or package, or at
+// https://github.com/restatedev/e2e/blob/main/LICENSE
+
+/// copied from our sdk-typescript
+//! Some parts copied from https://github.com/uuidjs/uuid/blob/main/src/stringify.js
+//! License MIT
+
+import { createHash } from "node:crypto";
+
+export class Random {
+  private randstate256: [bigint, bigint, bigint, bigint];
+
+  constructor(seed: string) {
+    const hash = createHash("sha256").update(seed).digest();
+
+    this.randstate256 = [
+      hash.readBigUInt64LE(0),
+      hash.readBigUInt64LE(8),
+      hash.readBigUInt64LE(16),
+      hash.readBigUInt64LE(24),
+    ];
+  }
+
+  static U64_MASK = (1n << 64n) - 1n;
+  static U53_MASK = (1n << 53n) - 1n;
+
+  // xoshiro256++
+  // https://prng.di.unimi.it/xoshiro256plusplus.c - public domain
+  public u64(): bigint {
+    const result: bigint =
+      (Random.rotl(
+        (this.randstate256[0] + this.randstate256[3]) & Random.U64_MASK,
+        23n
+      ) +
+        this.randstate256[0]) &
+      Random.U64_MASK;
+
+    const t: bigint = (this.randstate256[1] << 17n) & Random.U64_MASK;
+
+    this.randstate256[2] ^= this.randstate256[0];
+    this.randstate256[3] ^= this.randstate256[1];
+    this.randstate256[1] ^= this.randstate256[2];
+    this.randstate256[0] ^= this.randstate256[3];
+
+    this.randstate256[2] ^= t;
+
+    this.randstate256[3] = Random.rotl(this.randstate256[3], 45n);
+
+    return result;
+  }
+
+  public random(): number {
+    // first generate a uint in range [0,2^53), which can be mapped 1:1 to a float64 in [0,1)
+    const u53 = this.u64() & Random.U53_MASK;
+    // then divide by 2^53, which will simply update the exponent
+    return Number(u53) / 2 ** 53;
+  }
+
+  static rotl(x: bigint, k: bigint): bigint {
+    return ((x << k) & Random.U64_MASK) | (x >> (64n - k));
+  }
+}
+
+export class WeightedRandom<T> {
+  private readonly cdf: number[];
+
+  static from<K extends number | string | symbol>(
+    items: Record<K, number>
+  ): WeightedRandom<K> {
+    return new WeightedRandom<K>(
+      Object.keys(items) as K[],
+      Object.values(items)
+    );
+  }
+
+  constructor(private readonly items: T[], ranks: number[]) {
+    // compute PDF
+    let sum = 0;
+    for (const n of ranks) {
+      sum += n;
+    }
+    const pdf = ranks.map((n) => n / sum);
+    // compute CDF
+    const cdf = [pdf[0]];
+    for (let i = 1; i < ranks.length; i++) {
+      cdf[i] = cdf[i - 1] + pdf[i];
+    }
+    this.cdf = cdf;
+  }
+
+  next(random: Random): T {
+    const w = random.random();
+    const cdf = this.cdf;
+    for (let i = 0; i < cdf.length; i++) {
+      if (w <= cdf[i]) {
+        return this.items[i];
+      }
+    }
+    return this.items[this.items.length - 1];
+  }
+}

--- a/services/node-services/src/interpreter/services.ts
+++ b/services/node-services/src/interpreter/services.ts
@@ -1,0 +1,99 @@
+// Copyright (c) 2023 - Restate Software, Inc., Restate GmbH
+//
+// This file is part of the Restate e2e tests,
+// which are released under the MIT license.
+//
+// You can find a copy of the license in file LICENSE in the root
+// directory of this repository or package, or at
+// https://github.com/restatedev/e2e/blob/main/LICENSE
+
+import * as restate from "@restatedev/restate-sdk";
+import { CommandType, Program } from "./commands";
+import { interpreterObjectForLayer, type InterpreterId } from "./interpreter";
+
+/**
+ * The following is an auxiliary service that is being called
+ * by the interpreter objects
+ */
+
+export const serviceInterpreterHelper = restate.service({
+  name: "ServiceInterpreterHelper",
+  handlers: {
+    ping: async () => {},
+
+    echo: async (
+      _ctx: restate.Context,
+      parameters: string
+    ): Promise<string> => {
+      return parameters;
+    },
+
+    echoLater: async (
+      ctx: restate.Context,
+      parameter: { sleep: number; parameter: string }
+    ): Promise<string> => {
+      await ctx.sleep(parameter.sleep);
+      return parameter.parameter;
+    },
+
+    terminalFailure: async (): Promise<string> => {
+      throw new restate.TerminalError(`bye`);
+    },
+
+    incrementIndirectly: async (ctx: restate.Context, id: InterpreterId) => {
+      const program: Program = {
+        commands: [
+          {
+            kind: CommandType.INCREMENT_STATE_COUNTER,
+          },
+        ],
+      };
+
+      const obj = interpreterObjectForLayer(id.layer);
+
+      ctx.objectSendClient(obj, id.key).interpret(program);
+    },
+
+    resolveAwakeable: async (ctx: restate.Context, id: string) => {
+      ctx.resolveAwakeable(id, "ok");
+    },
+
+    rejectAwakeable: async (ctx: restate.Context, id: string) => {
+      ctx.rejectAwakeable(id, "error");
+    },
+
+    incrementViaAwakeableDance: async (
+      ctx: restate.Context,
+      input: { interpreter: InterpreterId; txPromiseId: string }
+    ) => {
+      //
+      // 1. create an awakeable that we will be blocked on
+      //
+      const { id, promise } = ctx.awakeable<string>();
+      //
+      // 2. send our awakeable id to the interpreter via txPromise.
+      //
+      ctx.resolveAwakeable(input.txPromiseId, id);
+      //
+      // 3. wait for the interpreter resolve us
+      //
+      await promise;
+      //
+      // 4. to thank our interpret, let us ask it to inc its state.
+      //
+      const program: Program = {
+        commands: [
+          {
+            kind: CommandType.INCREMENT_STATE_COUNTER,
+          },
+        ],
+      };
+
+      const obj = interpreterObjectForLayer(input.interpreter.layer);
+
+      ctx.objectSendClient(obj, input.interpreter.key).interpret(program);
+    },
+  },
+});
+
+export type ServiceInterpreterHelper = typeof serviceInterpreterHelper;

--- a/services/node-services/src/interpreter/test_driver.ts
+++ b/services/node-services/src/interpreter/test_driver.ts
@@ -1,0 +1,177 @@
+// Copyright (c) 2023 - Restate Software, Inc., Restate GmbH
+//
+// This file is part of the Restate e2e tests,
+// which are released under the MIT license.
+//
+// You can find a copy of the license in file LICENSE in the root
+// directory of this repository or package, or at
+// https://github.com/restatedev/e2e/blob/main/LICENSE
+
+import { Program, CommandType } from "./commands";
+import {
+  createInterpreterObject,
+  interpreterObjectForLayer,
+} from "./interpreter";
+import { Random } from "./random";
+import { ProgramGenerator } from "./test_generator";
+
+import * as restate from "@restatedev/restate-sdk";
+
+const MAX_LAYERS = 3;
+
+export interface TestConfiguration {
+  readonly ingress: string;
+  readonly seed: string;
+  readonly keys: number;
+  readonly tests: number;
+  readonly maxProgramSize: number;
+}
+
+export enum TestStatus {
+  NOT_STARTED = "NOT_STARTED",
+  RUNNING = "RUNNING",
+  VALIDATING = "VALIDATING",
+  FINISHED = "FINISHED",
+  FAILED = "FAILED",
+}
+
+class StateTracker {
+  private states: number[][] = [];
+
+  constructor(
+    private readonly numLayers: number,
+    private readonly numInterpreters: number
+  ) {
+    for (let i = 0; i < numLayers; i++) {
+      const layerState = Array.from({ length: this.numInterpreters }, () => 0);
+      this.states.push(layerState);
+    }
+  }
+
+  update(layer: number, id: number, program: Program) {
+    if (layer >= this.numLayers) {
+      throw new Error(`InterpreterDriver bug.`);
+    }
+    for (const command of program.commands) {
+      switch (command.kind) {
+        case CommandType.INCREMENT_STATE_COUNTER:
+        case CommandType.INCREMENT_STATE_COUNTER_INDIRECTLY:
+        case CommandType.INCREMENT_VIA_DELAYED_CALL:
+        case CommandType.INCREMENT_STATE_COUNTER_VIA_AWAKEABLE: {
+          this.states[layer][id] += 1;
+          break;
+        }
+        case CommandType.CALL_NEXT_LAYER_OBJECT: {
+          this.update(layer + 1, command.key, command.program);
+          break;
+        }
+      }
+    }
+  }
+
+  getLayer(layer: number): number[] {
+    return this.states[layer];
+  }
+}
+
+export class Test {
+  readonly random: Random;
+  readonly stateTracker: StateTracker;
+  readonly ingress: restate.ingress.Ingress;
+
+  status: TestStatus = TestStatus.NOT_STARTED;
+
+  constructor(readonly conf: TestConfiguration) {
+    this.random = new Random(conf.seed);
+    this.stateTracker = new StateTracker(MAX_LAYERS, conf.keys);
+    this.ingress = restate.ingress.connect({ url: this.conf.ingress });
+  }
+
+  testStatus(): TestStatus {
+    return this.status;
+  }
+
+  *generate() {
+    const testCaseCount = this.conf.tests;
+    const gen = new ProgramGenerator(
+      this.random,
+      this.conf.keys,
+      this.conf.maxProgramSize
+    );
+
+    for (let i = 0; i < testCaseCount; i++) {
+      const program = gen.generateProgram(0);
+      const id = Math.floor(this.random.random() * this.conf.keys);
+      yield { id, program };
+    }
+  }
+
+  async go(): Promise<TestStatus> {
+    this.status = TestStatus.RUNNING;
+    for (const b of batch(this.generate(), 16)) {
+      // TODO: add `idempotencyKey` once supported.
+      const promises = b.map(({ id, program }) =>
+        this.ingress.objectSendClient(InterpreterL0, `${id}`).interpret(program)
+      );
+
+      b.forEach(({ id, program }) => this.stateTracker.update(0, id, program));
+
+      await Promise.all(promises);
+    }
+
+    this.status = TestStatus.VALIDATING;
+    console.log("Done generating");
+
+    for (const layerId of [0, 1, 2]) {
+      while (!(await this.verifyLayer(layerId))) {
+        await new Promise((resolve) => setTimeout(resolve, 10 * 1000));
+      }
+      console.log(`Done validating layer ${layerId}`);
+    }
+
+    console.log("Done.");
+    this.status = TestStatus.FINISHED;
+    return TestStatus.FINISHED;
+  }
+
+  async verifyLayer(layerId: number): Promise<boolean> {
+    console.log(`Trying to verify layer ${layerId}`);
+
+    const layer = this.stateTracker.getLayer(layerId);
+    const interpreterLn = createInterpreterObject(layerId);
+    const futures = layer.map(async (expected, id) => {
+      const actual = await this.ingress
+        .objectClient(interpreterLn, `${id}`)
+        .counter();
+      return expected === actual;
+    });
+
+    const results = await Promise.all(futures);
+    for (let j = 0; j < layer.length; j++) {
+      const p = results[j];
+      if (!p) {
+        console.log(
+          `Found a mismatch at layer ${layerId} interpreter ${j}. This is expected, this interpreter might still have some backlog to process, and eventually it will catchup with the desired value. Will retry in few seconds.`
+        );
+        return false;
+      }
+    }
+    return true;
+  }
+}
+
+function* batch<T>(iterable: IterableIterator<T>, batchSize: number) {
+  let items: T[] = [];
+  for (const item of iterable) {
+    items.push(item);
+    if (items.length >= batchSize) {
+      yield items;
+      items = [];
+    }
+  }
+  if (items.length !== 0) {
+    yield items;
+  }
+}
+
+const InterpreterL0 = interpreterObjectForLayer(0);

--- a/services/node-services/src/interpreter/test_generator.ts
+++ b/services/node-services/src/interpreter/test_generator.ts
@@ -1,0 +1,277 @@
+// Copyright (c) 2023 - Restate Software, Inc., Restate GmbH
+//
+// This file is part of the Restate e2e tests,
+// which are released under the MIT license.
+//
+// You can find a copy of the license in file LICENSE in the root
+// directory of this repository or package, or at
+// https://github.com/restatedev/e2e/blob/main/LICENSE
+
+import { CommandType, Command, Program, AwaitPromise } from "./commands";
+import { Random, WeightedRandom } from "./random";
+
+/**
+ * The following module is responsible for generating instances of a {@link Program}.
+ * According to a predefined distributed.
+ * There is nothing here that defines correctness, it is just about
+ */
+
+/**
+ * L0 distribution represents the commands with their 'rank' (~ likelihood to appear)
+ * The exact statistical distribution is defined in the distribution function below.
+ */
+const L0 = distribution([
+  [
+    CommandType.GET_STATE,
+    CommandType.SET_STATE,
+    CommandType.CLEAR_STATE,
+    CommandType.SIDE_EFFECT,
+    CommandType.INCREMENT_STATE_COUNTER,
+  ],
+  [
+    CommandType.INCREMENT_STATE_COUNTER_INDIRECTLY,
+    CommandType.CALL_SERVICE,
+    CommandType.CALL_NEXT_LAYER_OBJECT,
+  ],
+  [CommandType.THROWING_SIDE_EFFECT, CommandType.RECOVER_TERMINAL_CALL],
+  [
+    CommandType.INCREMENT_STATE_COUNTER_VIA_AWAKEABLE,
+    CommandType.RESOLVE_AWAKEABLE,
+    CommandType.REJECT_AWAKEABLE,
+  ],
+  [
+    CommandType.CALL_SLOW_SERVICE,
+    CommandType.SLOW_SIDE_EFFECT,
+    CommandType.SLEEP,
+    CommandType.INCREMENT_VIA_DELAYED_CALL,
+    CommandType.RECOVER_TERMINAL_MAYBE_UN_AWAITED,
+  ],
+]);
+
+/**
+ * L1 distribution represents the commands with their 'rank' (~ likelihood to appear)
+ */
+const L1 = distribution([
+  [
+    CommandType.GET_STATE,
+    CommandType.SET_STATE,
+    CommandType.CLEAR_STATE,
+    CommandType.SIDE_EFFECT,
+    CommandType.INCREMENT_STATE_COUNTER,
+  ],
+  [CommandType.INCREMENT_STATE_COUNTER_INDIRECTLY, CommandType.CALL_SERVICE],
+  [CommandType.THROWING_SIDE_EFFECT, CommandType.RECOVER_TERMINAL_CALL],
+  [
+    CommandType.CALL_NEXT_LAYER_OBJECT,
+    CommandType.INCREMENT_STATE_COUNTER_VIA_AWAKEABLE,
+    CommandType.RESOLVE_AWAKEABLE,
+    CommandType.REJECT_AWAKEABLE,
+  ],
+  [
+    CommandType.CALL_SLOW_SERVICE,
+    CommandType.SLOW_SIDE_EFFECT,
+    CommandType.SLEEP,
+    CommandType.INCREMENT_VIA_DELAYED_CALL,
+    CommandType.RECOVER_TERMINAL_MAYBE_UN_AWAITED,
+  ],
+]);
+
+/**
+ * L2 distribution represents the commands with their 'rank' (~ likelihood to appear)
+ */
+const L2 = distribution([
+  [
+    CommandType.GET_STATE,
+    CommandType.SET_STATE,
+    CommandType.CLEAR_STATE,
+    CommandType.SIDE_EFFECT,
+    CommandType.INCREMENT_STATE_COUNTER,
+  ],
+  [CommandType.INCREMENT_STATE_COUNTER_INDIRECTLY, CommandType.CALL_SERVICE],
+  [CommandType.THROWING_SIDE_EFFECT, CommandType.RECOVER_TERMINAL_CALL],
+  [
+    CommandType.INCREMENT_STATE_COUNTER_VIA_AWAKEABLE,
+    CommandType.RESOLVE_AWAKEABLE,
+    CommandType.REJECT_AWAKEABLE,
+  ],
+  [
+    CommandType.CALL_SLOW_SERVICE,
+    CommandType.SLOW_SIDE_EFFECT,
+    CommandType.SLEEP,
+    CommandType.INCREMENT_VIA_DELAYED_CALL,
+    CommandType.RECOVER_TERMINAL_MAYBE_UN_AWAITED,
+  ],
+]);
+
+const MAX_NUMBER_OF_LEVELS = 3;
+const DISTRIBUTION_BY_LEVEL = [L0, L1, L2];
+
+export class ProgramGenerator {
+  constructor(
+    readonly rand: Random,
+    readonly interpreterCount: number,
+    readonly maximumCommandCount: number
+  ) {}
+
+  random(low: number, high: number): number {
+    return Math.floor(this.rand.random() * (high - low));
+  }
+
+  generateCommand(
+    commandType: CommandType,
+    currentLevel: number
+  ): Command | null {
+    if (commandType == CommandType.SET_STATE) {
+      return {
+        kind: CommandType.SET_STATE,
+        key: this.random(0, 6),
+      };
+    } else if (commandType == CommandType.GET_STATE) {
+      return {
+        kind: CommandType.GET_STATE,
+        key: this.random(0, 6),
+      };
+    } else if (commandType == CommandType.CLEAR_STATE) {
+      return {
+        kind: CommandType.CLEAR_STATE,
+        key: this.random(0, 6),
+      };
+    } else if (commandType == CommandType.INCREMENT_STATE_COUNTER) {
+      return { kind: CommandType.INCREMENT_STATE_COUNTER };
+    } else if (commandType == CommandType.INCREMENT_STATE_COUNTER_INDIRECTLY) {
+      return { kind: CommandType.INCREMENT_STATE_COUNTER_INDIRECTLY };
+    } else if (commandType == CommandType.SLEEP) {
+      return {
+        kind: CommandType.SLEEP,
+        duration: this.random(1, 101),
+      };
+    } else if (commandType == CommandType.CALL_SERVICE) {
+      return { kind: CommandType.CALL_SERVICE };
+    } else if (commandType == CommandType.CALL_SLOW_SERVICE) {
+      return {
+        kind: CommandType.CALL_SLOW_SERVICE,
+        sleep: this.random(1, 101),
+      };
+    } else if (commandType == CommandType.INCREMENT_VIA_DELAYED_CALL) {
+      return {
+        kind: CommandType.INCREMENT_VIA_DELAYED_CALL,
+        duration: this.random(1, 101),
+      };
+    } else if (commandType == CommandType.SIDE_EFFECT) {
+      return { kind: CommandType.SIDE_EFFECT };
+    } else if (commandType == CommandType.THROWING_SIDE_EFFECT) {
+      return { kind: CommandType.THROWING_SIDE_EFFECT };
+    } else if (commandType == CommandType.SLOW_SIDE_EFFECT) {
+      return { kind: CommandType.SLOW_SIDE_EFFECT };
+    } else if (commandType == CommandType.RECOVER_TERMINAL_CALL) {
+      return { kind: CommandType.RECOVER_TERMINAL_CALL };
+    } else if (commandType == CommandType.RECOVER_TERMINAL_MAYBE_UN_AWAITED) {
+      return { kind: CommandType.RECOVER_TERMINAL_MAYBE_UN_AWAITED };
+    } else if (commandType == CommandType.RESOLVE_AWAKEABLE) {
+      return { kind: CommandType.RESOLVE_AWAKEABLE };
+    } else if (commandType == CommandType.REJECT_AWAKEABLE) {
+      return { kind: CommandType.REJECT_AWAKEABLE };
+    } else if (
+      commandType == CommandType.INCREMENT_STATE_COUNTER_VIA_AWAKEABLE
+    ) {
+      return { kind: CommandType.INCREMENT_STATE_COUNTER_VIA_AWAKEABLE };
+    } else if (
+      commandType == CommandType.CALL_NEXT_LAYER_OBJECT &&
+      currentLevel < MAX_NUMBER_OF_LEVELS
+    ) {
+      const key = this.random(0, this.interpreterCount);
+      return {
+        kind: CommandType.CALL_NEXT_LAYER_OBJECT,
+        key,
+        program: this.generateProgram(currentLevel + 1),
+      };
+    }
+
+    return null;
+  }
+
+  generateProgram(currentLevel: number): Program {
+    const numCommands: number = this.random(0, this.maximumCommandCount);
+    const commands: Command[] = [];
+    const promises: number[] = [];
+    const rand = this.rand;
+    for (let i = 0; i < numCommands; i++) {
+      const commandType = DISTRIBUTION_BY_LEVEL[currentLevel].next(rand);
+      const command = this.generateCommand(commandType, currentLevel);
+      if (command === null) {
+        continue;
+      }
+      commands.push(command);
+      if (canBeAwaited(commandType)) {
+        promises.push(commands.length - 1);
+      }
+      if (promises.length > 0 && this.random(0, 100) < 80) {
+        const index = promises[0];
+        promises.shift();
+        const awaitCommand: AwaitPromise = {
+          kind: CommandType.AWAIT_PROMISE,
+          index,
+        };
+        commands.push(awaitCommand);
+      }
+    }
+    // last chance to await un-awaited commands
+    for (let i = 0; i < promises.length; i++) {
+      if (promises.length > 0 && this.random(0, 100) < 20) {
+        // 20% skip
+        continue;
+      }
+      const index = promises[i];
+      const awaitCommand: AwaitPromise = {
+        kind: CommandType.AWAIT_PROMISE,
+        index,
+      };
+      commands.push(awaitCommand);
+    }
+    return { commands: commands };
+  }
+}
+
+function distribution(ranks: CommandType[][]): WeightedRandom<CommandType> {
+  const commands: Record<CommandType, number> = {
+    [CommandType.SET_STATE]: 0,
+    [CommandType.GET_STATE]: 0,
+    [CommandType.CLEAR_STATE]: 0,
+    [CommandType.INCREMENT_STATE_COUNTER]: 0,
+    [CommandType.INCREMENT_STATE_COUNTER_INDIRECTLY]: 0,
+    [CommandType.SLEEP]: 0,
+    [CommandType.CALL_SERVICE]: 0,
+    [CommandType.CALL_SLOW_SERVICE]: 0,
+    [CommandType.INCREMENT_VIA_DELAYED_CALL]: 0,
+    [CommandType.SIDE_EFFECT]: 0,
+    [CommandType.THROWING_SIDE_EFFECT]: 0,
+    [CommandType.SLOW_SIDE_EFFECT]: 0,
+    [CommandType.RECOVER_TERMINAL_CALL]: 0,
+    [CommandType.RECOVER_TERMINAL_MAYBE_UN_AWAITED]: 0,
+    [CommandType.AWAIT_PROMISE]: 0,
+    [CommandType.RESOLVE_AWAKEABLE]: 0,
+    [CommandType.REJECT_AWAKEABLE]: 0,
+    [CommandType.INCREMENT_STATE_COUNTER_VIA_AWAKEABLE]: 0,
+    [CommandType.CALL_NEXT_LAYER_OBJECT]: 0,
+  };
+  //
+  // each group would have 2x smaller rank from the previous
+  //
+  let rank = 1 << (ranks.length + 1);
+  for (const group of ranks) {
+    for (const command of group) {
+      commands[command] = rank;
+    }
+    rank = rank >> 2;
+  }
+  return WeightedRandom.from(commands);
+}
+
+function canBeAwaited(commandType: CommandType): boolean {
+  return (
+    commandType == CommandType.CALL_SERVICE ||
+    commandType == CommandType.CALL_SLOW_SERVICE ||
+    commandType == CommandType.RECOVER_TERMINAL_MAYBE_UN_AWAITED ||
+    commandType == CommandType.CALL_NEXT_LAYER_OBJECT
+  );
+}

--- a/services/node-services/src/services.ts
+++ b/services/node-services/src/services.ts
@@ -18,7 +18,7 @@ export type IComponent = {
   binder: (endpoint: RestateEndpoint) => void;
 };
 
-export class ComponenetRegistery {
+export class ComponentRegistry {
   constructor(readonly components: Map<string, IComponent> = new Map()) {}
 
   add(c: IComponent) {
@@ -52,4 +52,4 @@ export class ComponenetRegistery {
   }
 }
 
-export const REGISTRY = new ComponenetRegistery();
+export const REGISTRY = new ComponentRegistry();


### PR DESCRIPTION
To test while in development:

```bash
cd services/node-services
npm run build
```

```bash
# don't forget to register the services 
restate dp add localhost:9080
```

```bash
SERVICES=ObjectInterpreterL0,ObjectInterpreterL1,ObjectInterpreterL2,ServiceInterpreterHelper,InterpreterDriver InterpreterDriverPort=3000 NODE_ENV=production NODE_OPTIONS="--max-old-space-size=4096" node dist/app.js
```

Test configuration

```
{
  "seed" : string,         // seeding the PRNG
  "ingress" : string,    // the ingress url
  "keys" : number,      // the number of different keys to use 
  "tests" : number,     // the number of test cases to generate
  "maxProgramSize": number,  // how large can a single test case get
}
```
Here is an example:
```bash
curl http://localhost:3000/start --json '{ "seed" : "whatever", "ingress" : "http://localhost:8080",  "keys" : 1024, "tests" : 10000, "maxProgramSize" : 15 }'

```

To query the status you can use:

```bash
curl localhost:3000/status
```
onces the test successfully finished the status will become 'FINISHED'
