### PR TITLE
[interpreter] Make it docker-composable 

### DIFF
--- a/services/node-services/compose/compose.template.yml
+++ b/services/node-services/compose/compose.template.yml
@@ -1,0 +1,37 @@
+services:
+  driver:
+    image: ghcr.io/restatedev/node-e2e-services 
+    ports:
+      - 3000:3000
+    depends_on:
+      interpreter:
+        condition: service_started
+      restate:
+        condition: service_started
+    environment:
+      NODE_ENV: production
+      NODE_OPTIONS: "--max-old-space-size=4096"
+      SERVICES: InterpreterDriverJob
+      INTERPRETER_DRIVER_CONF: ${INTERPRETER_DRIVER_CONF}
+    restart: no
+  interpreter:
+    image: ghcr.io/restatedev/node-e2e-services 
+    ports:
+      - 9080:9080
+    environment:
+      - NODE_ENV=production
+      - SERVICES=ObjectInterpreterL0,ObjectInterpreterL1,ObjectInterpreterL2,ServiceInterpreterHelper
+    restart: always
+  restate:
+    image: ghcr.io/restatedev/restate:main
+    ports:
+      - 8080:8080
+      - 9090:9090
+      - 9070:9070
+      - 8081:8081
+    restart: no
+    ulimits:
+      nproc: 65535
+      nofile:
+        soft: 65535
+        hard: 65535

--- a/services/node-services/compose/run.sh
+++ b/services/node-services/compose/run.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+SEED=$(date --iso-8601=seconds)
+TIMEOUT_SECNODS=3600
+
+export INTERPRETER_DRIVER_CONF=$(cat <<-EOF 
+			{
+        "seed" : "${SEED}", 
+        "keys" : 100,
+        "tests" : 100,
+        "maxProgramSize" : 15,
+        "ingress" : "http://restate:8080",
+        "register" : {
+          "adminUrl" : "http://restate:9070",
+          "deployments" : ["http://interpreter:9080"]
+        }
+      }
+EOF
+)
+
+
+docker-compose -f compose.template.yml up \
+	--abort-on-container-exit \
+	--exit-code-from driver \
+	--force-recreate \
+	--timeout ${TIMEOUT_SECNODS}
+
+

--- a/services/node-services/src/interpreter/driver.ts
+++ b/services/node-services/src/interpreter/driver.ts
@@ -16,7 +16,7 @@ let TEST: Test | undefined = undefined;
  * Start a runner as a batch job
  */
 export const createJob = async () => {
-  const conf = await readJSONFromStdin();
+  const conf = readJsonEnv();
   TEST = new Test(conf);
   return TEST.go();
 };
@@ -87,23 +87,10 @@ function writeJsonResponse(
   res.end();
 }
 
-function readJSONFromStdin(): Promise<TestConfiguration> {
-  return new Promise((resolve, reject) => {
-    let input = "";
-    process.stdin.setEncoding("utf-8");
-    process.stdin.on("readable", () => {
-      const chunk = process.stdin.read();
-      if (chunk !== null) {
-        input += chunk;
-      }
-    });
-    process.stdin.on("end", () => {
-      try {
-        const jsonData: TestConfiguration = JSON.parse(input.trim());
-        resolve(jsonData);
-      } catch (error) {
-        reject(error);
-      }
-    });
-  });
+function readJsonEnv(): TestConfiguration {
+  const conf = process.env.INTERPRETER_DRIVER_CONF;
+  if (!conf) {
+    throw new Error(`Missing INTERPRETER_DRIVER_CONF env var`);
+  }
+  return JSON.parse(conf) as TestConfiguration;
 }


### PR DESCRIPTION
This PR only effects the interpreter job (not the server) and makes it possible to pass in the test configuration via the env variable called `INTERPRETER_DRIVER_CONF`.
This works better with docker and docker-compose.

In addition it adds a `compose.template.yml` and a simple `run.sh` shell script to run the test.


