### PR TITLE
[node] Use ctx.key instead ctx.key()

### DIFF
--- a/services/node-services/src/cancel_test.ts
+++ b/services/node-services/src/cancel_test.ts
@@ -31,7 +31,7 @@ const cancelService = restate.object({
 
     async startTest(ctx: restate.ObjectContext, request: BlockingOperation) {
       try {
-        await ctx.objectClient(BlockingService, ctx.key()).block(request);
+        await ctx.objectClient(BlockingService, ctx.key).block(request);
       } catch (e) {
         if (
           e instanceof restate.TerminalError &&
@@ -57,7 +57,7 @@ const blockingService = restate.object({
 
       switch (request) {
         case BlockingOperation.CALL: {
-          await ctx.objectClient(BlockingService, ctx.key()).block(request);
+          await ctx.objectClient(BlockingService, ctx.key).block(request);
           break;
         }
         case BlockingOperation.SLEEP: {

--- a/services/node-services/src/counter.ts
+++ b/services/node-services/src/counter.ts
@@ -30,7 +30,7 @@ const service = restate.object({
     async addThenFail(ctx: restate.ObjectContext, value: number) {
       const counter = (await ctx.get<number>(COUNTER_KEY)) ?? 0;
       ctx.set(COUNTER_KEY, counter + value);
-      throw new restate.TerminalError(ctx.key());
+      throw new restate.TerminalError(ctx.key);
     },
 
     async get(ctx: restate.ObjectContext): Promise<number> {
@@ -53,7 +53,7 @@ const service = restate.object({
 
       // Wait for the sync with the test runner
       const { id, promise } = ctx.awakeable();
-      ctx.objectSendClient(AwakeableHolder, ctx.key()).hold(id);
+      ctx.objectSendClient(AwakeableHolder, ctx.key).hold(id);
       await promise;
 
       // Now start looping

--- a/services/node-services/src/event_handler.ts
+++ b/services/node-services/src/event_handler.ts
@@ -19,7 +19,7 @@ const o = restate.object({
   name: EventHandlerFQN,
   handlers: {
     async handle(ctx: restate.ObjectContext, value: number) {
-      ctx.objectSendClient(CounterApi, ctx.key()).add(value);
+      ctx.objectSendClient(CounterApi, ctx.key).add(value);
     },
   },
 });

--- a/services/node-services/src/interpreter/interpreter.ts
+++ b/services/node-services/src/interpreter/interpreter.ts
@@ -71,7 +71,7 @@ class ProgramInterpreter {
     layer: number,
     ctx: restate.ObjectContext
   ): ProgramInterpreter {
-    const id = { layer, key: ctx.key() };
+    const id = { layer, key: ctx.key };
     return new ProgramInterpreter(ctx, id);
   }
 

--- a/services/node-services/src/non_determinism.ts
+++ b/services/node-services/src/non_determinism.ts
@@ -19,13 +19,13 @@ const Counter: CounterApi = { name: "Counter" };
 const invocationCounts = new Map<string, number>();
 
 function doLeftAction(ctx: restate.ObjectContext): boolean {
-  const newValue = (invocationCounts.get(ctx.key()) ?? 0) + 1;
-  invocationCounts.set(ctx.key(), newValue);
+  const newValue = (invocationCounts.get(ctx.key) ?? 0) + 1;
+  invocationCounts.set(ctx.key, newValue);
   return newValue % 2 == 1;
 }
 
 function incrementCounter(ctx: restate.ObjectContext) {
-  ctx.objectSendClient(Counter, ctx.key()).add(1);
+  ctx.objectSendClient(Counter, ctx.key).add(1);
 }
 
 const o = restate.object({


### PR DESCRIPTION
Adjust to the latest changes in the typescript SDK
note: needs to merge the sdk changes first.