### PR TITLE
Lower retry delay to 50ms

### DIFF
--- a/tests/src/test/kotlin/dev/restate/e2e/node/InterpreterTest.kt
+++ b/tests/src/test/kotlin/dev/restate/e2e/node/InterpreterTest.kt
@@ -46,6 +46,7 @@ class InterpreterTest {
     @RegisterExtension
     val deployerExt: RestateDeployerForEachExtension = RestateDeployerForEachExtension {
       RestateDeployer.Builder()
+          .withInvokerRetryPolicy(RestateDeployer.RetryPolicy.FixedDelay("50ms", Int.MAX_VALUE))
           .withServiceEndpoint(
               Containers.nodeServicesContainer(
                   "intepreter",


### PR DESCRIPTION
Since retries are expected for the InterpreterTest, we lower the delay between retries to avoid running into test timeouts because of too many retries with a long delay in-between as it happened here: https://github.com/restatedev/e2e/actions/runs/8831342633/job/24246356686?pr=324.