### PR TITLE
Look for ci.yml instead of docker.yml when manually running e2e.yml

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -165,7 +165,7 @@ jobs:
         uses: dawidd6/action-download-artifact@v3
         with:
           repo: restatedev/restate
-          workflow: docker.yml
+          workflow: ci.yml
           commit: ${{ inputs.restateCommit }}
           name: restate.tar
 


### PR DESCRIPTION
The problem is that we no longer directly use docker.yml to build the restate.tar. However, every commit we push will trigger the ci.yml workflow which also creates the restate.tar. Therefore, this commit changes it so that manually triggered e2e runs with a specified restate sha work again.