### PR TITLE
[node] Bump the verification test parameters

### DIFF
--- a/.github/workflows/verification.yaml
+++ b/.github/workflows/verification.yaml
@@ -16,7 +16,7 @@ jobs:
     # prevent running on forks
     if: github.repository_owner == 'restatedev'
     runs-on: warp-ubuntu-latest-x64-16x # warpbuild runner
-    timeout-minutes: 70
+    timeout-minutes: 250 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/services/node-services/compose/run.sh
+++ b/services/node-services/compose/run.sh
@@ -1,15 +1,15 @@
 #!/usr/bin/env bash
 
 SEED=$(date --iso-8601=seconds)
-TIMEOUT_SECNODS=3600
+TIMEOUT_SECNODS=14400
 EXPECTED_NOISY_LOG_MESSAGE="undefined is not a number, but it still has feelings"
 
 export INTERPRETER_DRIVER_CONF=$(cat <<-EOF 
 			{
         "seed" : "${SEED}", 
-        "keys" : 10000,
-        "tests" : 100000,
-        "maxProgramSize" : 15,
+        "keys" : 100000,
+        "tests" : 1000000,
+        "maxProgramSize" : 50,
         "ingress" : "http://restate:8080",
         "register" : {
 					"adminUrl" : "http://restate:9070",


### PR DESCRIPTION
The nightly verification test finishes in around 5-6 minutes.
Let us bump the test parameters to stress the system further.