### PR TITLE
Revert setting auto recovery interval to 2s

### DIFF
--- a/src/main/kotlin/dev/restate/sdktesting/infra/RestateContainer.kt
+++ b/src/main/kotlin/dev/restate/sdktesting/infra/RestateContainer.kt
@@ -91,7 +91,6 @@ class RestateContainer(
                   "RESTATE_METADATA_SERVER__TYPE" to "replicated",
                   "RESTATE_METADATA_CLIENT__ADDRESSES" to
                       "[http://$RESTATE_RUNTIME:$RUNTIME_NODE_PORT]",
-                  "RESTATE_BIFROST__AUTO_RECOVERY_INTERVAL" to "2s",
               )
 
       return listOf(


### PR DESCRIPTION
With https://github.com/restatedev/restate/commit/6e7b249af8d9b044efcb5c5b72e849f88b5c4799 we are reconfiguring the logs automatically. And with https://github.com/restatedev/restate/commit/0d2bae7b7b10d52b2ece7c995849109e2ede8704, we no longer rely on the cluster controller to reconfigure logs. Hence, we can revert the temporary band aid which decreased the auto recovery interval to a value so that tests were passing even though the logs controller didn't notice.