### PR TITLE
Bump last compatible restate server version to 1.6.2

### DIFF
--- a/src/main/kotlin/dev/restate/sdktesting/tests/BackwardCompatibilityTest.kt
+++ b/src/main/kotlin/dev/restate/sdktesting/tests/BackwardCompatibilityTest.kt
@@ -279,8 +279,6 @@ class BackwardCompatibilityTest {
           DeploymentApi(
               ApiClient()
                   .setHost(adminURI.host)
-                  // TODO remove basePath
-                  .setBasePath("/v2")
                   .setPort(adminURI.port))
 
       // List all deployments

--- a/src/main/kotlin/dev/restate/sdktesting/tests/Constants.kt
+++ b/src/main/kotlin/dev/restate/sdktesting/tests/Constants.kt
@@ -9,9 +9,5 @@
 package dev.restate.sdktesting.tests
 
 object Constants {
-
-  // TODO When bumping this to 1.6, uncomment usage of
-  //  .setBasePath("/v2")
-  //  in Back and Front CompatiblityTest
-  val LAST_COMPATIBLE_RESTATE_SERVER_VERSION = "1.5.1"
+  val LAST_COMPATIBLE_RESTATE_SERVER_VERSION = "1.6.2"
 }

--- a/src/main/kotlin/dev/restate/sdktesting/tests/ForwardCompatibilityTest.kt
+++ b/src/main/kotlin/dev/restate/sdktesting/tests/ForwardCompatibilityTest.kt
@@ -266,8 +266,6 @@ class ForwardCompatibilityTest {
       val adminClient =
           ApiClient()
               .setHost(adminURI.host)
-              // TODO remove basePath
-              .setBasePath("/v2")
               .setPort(adminURI.port)
       val adminApi = DeploymentApi(adminClient)
 


### PR DESCRIPTION
Bump last compatible restate server version to 1.6.2 in preparation of the v1.7 release.