### PR TITLE
Replace the deprecated /cluster-health endpoint with gRPC call

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,6 +5,7 @@ plugins {
 
   id("org.jsonschema2pojo") version "1.2.2" apply false
   alias(libs.plugins.openapi.generator) apply false
+  alias(libs.plugins.protobuf) apply false
 
   id("com.diffplug.spotless") version "6.25.0" apply false
   id("com.github.jk1.dependency-license-report") version "2.9" apply false

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -7,6 +7,9 @@ junit = "6.0.3"
 assertj = "3.27.6"
 testcontainers = "2.0.4"
 awaitility = "4.3.0"
+grpc = "1.68.1"
+protobuf = "3.25.5"
+protobufPlugin = "0.9.4"
 
 [libraries]
 # Restate SDK
@@ -71,6 +74,13 @@ kaml = { module = "com.charleskorn.kaml:kaml", version = "0.102.0" }
 kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version = "1.10.1" }
 kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version = "1.10.1" }
 
+# gRPC / Protobuf (used by infra to talk to Restate metadata-server gRPC)
+protobuf-java = { module = "com.google.protobuf:protobuf-java", version.ref = "protobuf" }
+grpc-protobuf = { module = "io.grpc:grpc-protobuf", version.ref = "grpc" }
+grpc-stub = { module = "io.grpc:grpc-stub", version.ref = "grpc" }
+grpc-netty-shaded = { module = "io.grpc:grpc-netty-shaded", version.ref = "grpc" }
+
 [plugins]
 openapi-generator = { id = "org.openapi.generator", version = "7.5.0" }
 shadow = { id = "com.gradleup.shadow", version = "8.3.5" }
+protobuf = { id = "com.google.protobuf", version.ref = "protobufPlugin" }

--- a/infra/build.gradle.kts
+++ b/infra/build.gradle.kts
@@ -1,3 +1,4 @@
+import com.google.protobuf.gradle.id
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 import org.openapitools.generator.gradle.plugin.tasks.GenerateTask
 
@@ -7,6 +8,7 @@ plugins {
 
   id("org.jsonschema2pojo")
   alias(libs.plugins.openapi.generator)
+  alias(libs.plugins.protobuf)
 
   id("com.diffplug.spotless")
   id("com.github.jk1.dependency-license-report")
@@ -19,7 +21,11 @@ val generatedOpenapi = layout.buildDirectory.dir("generated/openapi")
 
 sourceSets {
   main {
-    java.srcDirs(generatedJ2SPDir, layout.buildDirectory.dir("generated/openapi/src/main/java"))
+    java.srcDirs(
+        generatedJ2SPDir,
+        layout.buildDirectory.dir("generated/openapi/src/main/java"),
+        layout.buildDirectory.dir("generated/source/proto/main/java"),
+        layout.buildDirectory.dir("generated/source/proto/main/grpc"))
   }
 }
 
@@ -65,6 +71,11 @@ dependencies {
 
   implementation(libs.assertj)
   implementation(libs.awaitility)
+
+  implementation(libs.protobuf.java)
+  implementation(libs.grpc.protobuf)
+  implementation(libs.grpc.stub)
+  implementation(libs.grpc.netty.shaded)
 }
 
 jsonSchema2Pojo {
@@ -97,11 +108,18 @@ openApiGenerate {
   configOptions.put("openApiNullable", "false")
 }
 
+protobuf {
+  protoc { artifact = "com.google.protobuf:protoc:${libs.versions.protobuf.get()}" }
+  plugins { id("grpc") { artifact = "io.grpc:protoc-gen-grpc-java:${libs.versions.grpc.get()}" } }
+  generateProtoTasks { all().forEach { it.plugins { id("grpc") } } }
+}
+
 tasks {
   withType<KotlinCompile>().configureEach {
     dependsOn(openApiGenerate)
     dependsOn(generateJsonSchema2Pojo)
     dependsOn(withType<GenerateTask>())
+    dependsOn(withType<com.google.protobuf.gradle.GenerateProtoTask>())
   }
 }
 

--- a/infra/src/main/kotlin/dev/restate/sdktesting/infra/RestateDeployer.kt
+++ b/infra/src/main/kotlin/dev/restate/sdktesting/infra/RestateDeployer.kt
@@ -8,7 +8,7 @@
 // https://github.com/restatedev/sdk-test-suite/blob/main/LICENSE
 package dev.restate.sdktesting.infra
 
-import dev.restate.admin.api.ClusterHealthApi
+import com.google.protobuf.Empty
 import dev.restate.admin.api.DeploymentApi
 import dev.restate.admin.client.ApiClient
 import dev.restate.admin.client.ApiException
@@ -18,6 +18,8 @@ import dev.restate.sdk.endpoint.Endpoint
 import dev.restate.sdk.http.vertx.RestateHttpServer
 import dev.restate.sdktesting.infra.runtimeconfig.IngressOptions
 import dev.restate.sdktesting.infra.runtimeconfig.RestateConfigSchema
+import io.grpc.ManagedChannelBuilder
+import io.grpc.StatusRuntimeException
 import io.vertx.core.http.HttpServer
 import java.io.File
 import java.net.URI
@@ -42,6 +44,7 @@ import org.testcontainers.images.builder.Transferable
 import org.testcontainers.shaded.com.fasterxml.jackson.databind.ser.impl.SimpleBeanPropertyFilter
 import org.testcontainers.shaded.com.fasterxml.jackson.databind.ser.impl.SimpleFilterProvider
 import org.testcontainers.shaded.com.github.dockerjava.core.DockerClientConfig
+import restate.metadata_server_svc.MetadataServerSvcGrpc
 
 class RestateDeployer
 private constructor(
@@ -362,20 +365,18 @@ private constructor(
     val numberRestateNodes = runtimeContainers.size
 
     Unreliables.retryUntilTrue(60, TimeUnit.SECONDS) {
+      val randomRestateNode = runtimeContainers.random()
+      val nodePort = randomRestateNode.getMappedPort(RUNTIME_NODE_PORT)
+      val channel = ManagedChannelBuilder.forAddress("localhost", nodePort).usePlaintext().build()
       try {
-        val randomRestateNode = runtimeContainers.random()
-        val adminPort = randomRestateNode.getMappedPort(RUNTIME_ADMIN_ENDPOINT_PORT)
-        val client =
-            ClusterHealthApi(
-                ApiClient(HttpClient.newBuilder(), apiClient.objectMapper, null)
-                    .setHost("localhost")
-                    .setPort(adminPort))
-        client.clusterHealth().metadataClusterHealth?.members?.size == numberRestateNodes
-      } catch (e: ApiException) {
+        val response =
+            MetadataServerSvcGrpc.newBlockingStub(channel).status(Empty.getDefaultInstance())
+        response.hasConfiguration() && response.configuration.membersCount == numberRestateNodes
+      } catch (e: StatusRuntimeException) {
         Thread.sleep(200)
-        throw IllegalStateException(
-            "Error when checking cluster health, got status code ${e.code} with body: ${e.responseBody}",
-            e)
+        throw IllegalStateException("Error when checking metadata server status: ${e.status}", e)
+      } finally {
+        channel.shutdownNow()
       }
     }
   }

--- a/infra/src/main/proto/metadata_server_svc.proto
+++ b/infra/src/main/proto/metadata_server_svc.proto
@@ -1,0 +1,144 @@
+// Copyright (c) 2024 - Restate Software, Inc., Restate GmbH
+//
+// This file is part of the Restate service protocol, which is
+// released under the MIT license.
+//
+// You can find a copy of the license in file LICENSE in the root
+// directory of this repository or package, or at
+// https://github.com/restatedev/proto/blob/main/LICENSE
+
+syntax = "proto3";
+
+import "google/protobuf/empty.proto";
+import "restate/common.proto";
+import "restate/metadata.proto";
+
+package restate.metadata_server_svc;
+
+// Grpc service definition for a MetadataStore implementation.
+service MetadataServerSvc {
+  // Get a versioned kv-pair
+  rpc Get(GetRequest) returns (GetResponse);
+
+  // Get the current version for a kv-pair
+  rpc GetVersion(GetRequest) returns (GetVersionResponse);
+
+  // Puts the given kv-pair into the metadata store
+  rpc Put(PutRequest) returns (google.protobuf.Empty);
+
+  // Deletes the given kv-pair
+  rpc Delete(DeleteRequest) returns (google.protobuf.Empty);
+
+  // Provisions the metadata store with the given input
+  rpc Provision(ProvisionRequest) returns (ProvisionResponse);
+
+  // Returns the status of the metadata store svc
+  rpc Status(google.protobuf.Empty) returns (StatusResponse);
+
+  // Instructs the node to join the metadata cluster
+  rpc AddNode(google.protobuf.Empty) returns (google.protobuf.Empty);
+
+  // Remove the given node from the metadata cluster. This operation can only be executed by the leader.
+  rpc RemoveNode(RemoveNodeRequest) returns (google.protobuf.Empty);
+}
+
+message GetRequest {
+  string key = 1;
+  // Cluster fingerprint for validation. If set to 0, then this field is ignored (for backward compatibility and allowing bootstrapping of a cluster).
+  uint64 cluster_fingerprint = 2;
+  // Cluster name for validation. Optional to support backward compatibility.
+  optional string cluster_name = 3;
+}
+
+message PutRequest {
+  string key = 1;
+  restate.metadata.VersionedValue value = 2;
+  restate.metadata.Precondition precondition = 3;
+  // Cluster fingerprint for validation. If set to 0, then this field is ignored (for backward compatibility and allowing bootstrapping of a cluster).
+  uint64 cluster_fingerprint = 4;
+  // Cluster name for validation. Optional to support backward compatibility.
+  optional string cluster_name = 5;
+}
+
+message DeleteRequest {
+  string key = 1;
+  restate.metadata.Precondition precondition = 2;
+  // Cluster fingerprint for validation. If set to 0, then this field is ignored (for backward compatibility and allowing bootstrapping of a cluster).
+  uint64 cluster_fingerprint = 3;
+  // Cluster name for validation. Optional to support backward compatibility.
+  optional string cluster_name = 4;
+}
+
+message GetResponse { optional restate.metadata.VersionedValue value = 1; }
+
+message GetVersionResponse { optional restate.common.Version version = 1; }
+
+message ProvisionRequest { bytes nodes_configuration = 1; }
+
+message ProvisionResponse { bool newly_provisioned = 1; }
+
+message RemoveNodeRequest {
+  uint32 plain_node_id = 1;
+  // optional field to uniquely identify a given cluster member
+  optional int64 created_at_millis = 2;
+}
+
+message StatusResponse {
+  restate.common.MetadataServerStatus status = 1;
+  optional MetadataServerConfiguration configuration = 2;
+  optional uint32 leader = 3;
+  optional SnapshotSummary snapshot = 4;
+  optional RaftSummary raft = 5;
+}
+
+message MetadataServerConfiguration {
+  restate.common.Version version = 1;
+  map<uint32, int64> members = 2;
+}
+
+message SnapshotSummary {
+  uint64 index = 1;
+  uint64 size = 2;
+}
+
+message RaftSummary {
+  uint64 term = 1;
+  uint64 applied = 2;
+  uint64 committed = 3;
+  uint64 first_index = 4;
+  uint64 last_index = 5;
+}
+
+// Ulid is a u128, which is not supported
+// by protobuf so instead we built it out of
+// 2 uint64 which is more efficient than a
+// bytes type.
+message Ulid {
+  uint64 low = 1;
+  uint64 high = 2;
+}
+
+enum WriteRequestKind {
+  WriteRequestKind_UNKNOWN = 0;
+  Put = 1;
+  Delete = 2;
+}
+
+message WriteRequest {
+  Ulid request_id = 1;
+  WriteRequestKind kind = 2;
+  bytes key = 3;
+  restate.metadata.Precondition precondition = 4;
+  // value is only required if WriteRequestKind is set to PUT
+  optional restate.metadata.VersionedValue value = 7;
+}
+
+message KvEntry {
+  bytes key = 1;
+  restate.metadata.VersionedValue value = 2;
+}
+
+message MetadataServerSnapshot {
+  MetadataServerConfiguration configuration = 1;
+  repeated KvEntry entries = 2;
+}

--- a/infra/src/main/proto/restate/common.proto
+++ b/infra/src/main/proto/restate/common.proto
@@ -1,0 +1,139 @@
+// Copyright (c) 2024 - Restate Software, Inc., Restate GmbH
+//
+// This file is part of the Restate service protocol, which is
+// released under the MIT license.
+//
+// You can find a copy of the license in file LICENSE in the root
+// directory of this repository or package, or at
+// https://github.com/restatedev/proto/blob/main/LICENSE
+
+syntax = "proto3";
+
+package restate.common;
+
+enum ProtocolVersion {
+  ProtocolVersion_UNKNOWN = 0;
+  reserved 1;
+  // Released in v1.2. Support dropped in v1.5.0
+  // V1 = 1;
+  // [Native RPC] Released in >= v1.3.3
+  V2 = 2;
+
+  // Release in v1.6. Support custom `Record`
+  // encoding that uses Bytes instead of PolyBytes
+  V3 = 3;
+}
+
+message NodeId {
+  uint32 id = 1;
+  optional uint32 generation = 2;
+}
+
+message GenerationalNodeId {
+  uint32 id = 1;
+  uint32 generation = 2;
+}
+
+// Partition Processor leadership epoch number
+message LeaderEpoch { uint64 value = 1; }
+
+// Log sequence number
+message Lsn { uint64 value = 1; }
+
+// A generic type for versioned metadata
+message Version { uint32 value = 1; }
+
+// The handle name or type tag of the message. For every service there must be
+// exactly one message handler implementation.
+enum ServiceTag {
+  reserved 1 to 25, 40 to 43, 50 to 53, 60, 61, 80 to 85  ;
+  ServiceTag_UNKNOWN = 0;
+  // LogServer
+  LOG_SERVER_DATA_SERVICE = 26;
+  LOG_SERVER_META_SERVICE = 27;
+
+  // ReplicatedLoglet
+  SEQUENCER_DATA_SERVICE = 44;
+  SEQUENCER_META_SERVICE = 45;
+  // Partition Processor
+  PARTITION_MANAGER_SERVICE = 54;
+  PARTITION_LEADER_SERVICE = 55;
+
+  // Failure detector
+  GOSSIP_SERVICE = 62;
+
+  // Data fusion
+  REMOTE_DATA_FUSION_SERVICE = 86;
+
+  // Metadata management
+  METADATA_MANAGER_SERVICE = 100;
+}
+
+// ** Health & Per-role Status
+
+enum NodeStatus {
+  NodeStatus_UNKNOWN = 0;
+  // The node has joined the cluster and is fully operational.
+  ALIVE = 1;
+  // The node is not fully running yet.
+  STARTING_UP = 2;
+  // The node is performing a graceful shutdown.
+  SHUTTING_DOWN = 3;
+}
+
+enum NodeRpcStatus {
+  NodeRpcStatus_UNKNOWN = 0;
+  NodeRpcStatus_READY = 1;
+  NodeRpcStatus_STARTING_UP = 2;
+  NodeRpcStatus_STOPPING = 3;
+}
+
+enum WorkerStatus {
+  WorkerStatus_UNKNOWN = 0;
+  WorkerStatus_READY = 1;
+  WorkerStatus_STARTING_UP = 2;
+}
+
+enum AdminStatus {
+  AdminStatus_UNKNOWN = 0;
+  AdminStatus_READY = 1;
+  AdminStatus_STARTING_UP = 2;
+}
+
+enum LogServerStatus {
+  LogServerStatus_UNKNOWN = 0;
+  LogServerStatus_READY = 1;
+  LogServerStatus_STARTING_UP = 2;
+  LogServerStatus_FAILSAFE = 3;
+  LogServerStatus_STOPPING = 4;
+}
+
+enum MetadataServerStatus {
+  MetadataServerStatus_UNKNOWN = 0;
+  MetadataServerStatus_STARTING_UP = 1;
+  MetadataServerStatus_AWAITING_PROVISIONING = 2;
+  MetadataServerStatus_MEMBER = 3;
+  MetadataServerStatus_STANDBY = 4;
+}
+
+enum IngressStatus {
+  IngressStatus_UNKNOWN = 0;
+  IngressStatus_READY = 1;
+  IngressStatus_STARTING_UP = 2;
+}
+
+enum MetadataKind {
+  MetadataKind_UNKNOWN = 0;
+  NODES_CONFIGURATION = 1;
+  SCHEMA = 2;
+  PARTITION_TABLE = 3;
+  LOGS = 4;
+}
+
+enum DatabaseKind {
+  DATABASE_KIND_UNSPECIFIED = 0;
+  DATABASE_KIND_PARTITION_STORE = 2;
+  DATABASE_KIND_LOG_SERVER = 3;
+  DATABASE_KIND_METADATA_SERVER = 4;
+  DATABASE_KIND_LOCAL_LOGLET = 5;
+}

--- a/infra/src/main/proto/restate/metadata.proto
+++ b/infra/src/main/proto/restate/metadata.proto
@@ -1,0 +1,33 @@
+// Copyright (c) 2025 - Restate Software, Inc., Restate GmbH
+//
+// This file is part of the Restate service protocol, which is
+// released under the MIT license.
+//
+// You can find a copy of the license in file LICENSE in the root
+// directory of this repository or package, or at
+// https://github.com/restatedev/proto/blob/main/LICENSE
+
+syntax = "proto3";
+
+package restate.metadata;
+
+import "google/protobuf/empty.proto";
+import "restate/common.proto";
+
+message VersionedValue {
+  restate.common.Version version = 1;
+  bytes bytes = 2;
+}
+
+enum PreconditionKind {
+  PreconditionKind_UNKNOWN = 0;
+  NONE = 1;
+  DOES_NOT_EXIST = 2;
+  MATCHES_VERSION = 3;
+}
+
+message Precondition {
+  PreconditionKind kind = 1;
+  // needs to be set in case of PreconditionKind::MATCHES_VERSION
+  optional restate.common.Version version = 2;
+}


### PR DESCRIPTION
Replace the deprecated /cluster-health endpoint with gRPC call

Summary:
This drops the use of the deprecated /cluster-health endpoint
and use the Restate metadata server gRPC service instead
